### PR TITLE
Update neighboring

### DIFF
--- a/Examples/LJ_langevin.py
+++ b/Examples/LJ_langevin.py
@@ -39,8 +39,6 @@ skin = 0.5 * unit.nanometer
 nbr_list = NeighborListNsqrd(
     OrthogonalPeriodicSpace(), cutoff=cutoff, skin=skin, n_max_neighbors=180
 )
-from chiron.neighbors import PairList
-
 
 # build the neighbor list from the sampler state
 nbr_list.build_from_state(sampler_state)

--- a/chiron/mcmc.py
+++ b/chiron/mcmc.py
@@ -412,6 +412,7 @@ class MetropolizedMove(MCMove):
         log.debug(f"Initial positions are {initial_positions} nm.")
         # Propose perturbed positions. Modifying the reference changes the sampler state.
         proposed_positions = self._propose_positions(initial_positions)
+
         log.debug(f"Proposed positions are {proposed_positions} nm.")
         # Compute the energy of the proposed positions.
         if atom_subset is None:
@@ -420,6 +421,10 @@ class MetropolizedMove(MCMove):
             sampler_state.x0 = sampler_state.x0.at[jnp.array(atom_subset)].set(
                 proposed_positions
             )
+        if nbr_list is not None:
+            if nbr_list.check(sampler_state.x0):
+                nbr_list.build(sampler_state.x0, sampler_state.box_vectors)
+
         proposed_energy = thermodynamic_state.get_reduced_potential(
             sampler_state, nbr_list
         )  # NOTE: in kT

--- a/chiron/neighbors.py
+++ b/chiron/neighbors.py
@@ -39,6 +39,10 @@ class Space(ABC):
                     )
 
                 self.box_vectors = box_vectors
+            else:
+                raise TypeError(
+                    f"box_vectors must be a jnp.array or unit.Quantity, not {type(box_vectors)}"
+                )
 
     @property
     def box_vectors(self) -> jnp.array:

--- a/chiron/neighbors.py
+++ b/chiron/neighbors.py
@@ -14,9 +14,31 @@ from abc import ABC, abstractmethod
 
 
 class Space(ABC):
-    def __init__(self, box_vectors: Optional[jnp.array] = None) -> None:
+    def __init__(
+        self, box_vectors: Union[jnp.array, unit.Quantity, None] = None
+    ) -> None:
+        """
+        Abstract base class for defining the simulation space.
+
+        Parameters
+        ----------
+        box_vectors: jnp.array, optional
+            Box vectors for the system.
+        """
         if box_vectors is not None:
-            self.box_vectors = box_vectors
+            if isinstance(box_vectors, unit.Quantity):
+                if not box_vectors.unit.is_compatible(unit.nanometer):
+                    raise ValueError(
+                        f"Box vectors require distance unit, not {box_vectors.unit}"
+                    )
+                self.box_vectors = box_vectors.value_in_unit_system(unit.md_unit_system)
+            elif isinstance(box_vectors, jnp.ndarray):
+                if box_vectors.shape != (3, 3):
+                    raise ValueError(
+                        f"box_vectors should be a 3x3 array, shape provided: {box_vectors.shape}"
+                    )
+
+                self.box_vectors = box_vectors
 
     @property
     def box_vectors(self) -> jnp.array:
@@ -39,20 +61,9 @@ class Space(ABC):
 
 class OrthogonalPeriodicSpace(Space):
     """
-    Calculate the periodic distance between two points.
+    Defines the simulation space for an orthogonal periodic system.
 
-    Returns
-    -------
-    Callable
-        Function that calculates the periodic displacement and distance between two points
     """
-
-    def __init__(self, box_vectors: Optional[jnp.array] = None) -> None:
-        super().__init__(box_vectors)
-        if box_vectors is not None:
-            self.box_lengths = jnp.array(
-                [box_vectors[0][0], box_vectors[1][1], box_vectors[2][2]]
-            )
 
     @property
     def box_vectors(self) -> jnp.array:
@@ -176,7 +187,7 @@ class OrthogonalNonperiodicSpace(Space):
 
 class PairsBase(ABC):
     """
-    Base class for pairlist implementations that returns the particle pair ids, displacement vectors, and distances.
+    Abstract Base Class for different algorithms that determine which particles are interacting.
 
     Parameters
     ----------
@@ -185,7 +196,26 @@ class PairsBase(ABC):
     cutoff: float, default = 2.5
         Cutoff distance for the neighborlist
 
-    Examples"""
+    Examples
+    --------
+    >>> from chiron.neighbors import PairsBase, OrthogonalPeriodicSpace
+    >>> from chiron.states import SamplerState
+    >>> from openmm as unit
+    >>> import jax.numpy as jnp
+    >>>
+    >>> space = OrthogonalPeriodicSpace() # define the simulation space, in this case an orthogonal periodic space
+    >>> sampler_state = SamplerState(x0=jnp.array([[0.0, 0.0, 0.0], [2, 0.0, 0.0], [0.0, 2, 0.0]]),
+    >>>                              box_vectors=jnp.array([[10, 0.0, 0.0], [0.0, 10, 0.0], [0.0, 0.0, 10]]))
+    >>>
+    >>> pair_list = PairsBase(space, cutoff=2.5*unit.nanometer) # initialize the pair list
+    >>> pair_list.build_from_state(sampler_state) # build the pair list from the sampler state
+    >>>
+    >>> coordinates = sampler_state.x0 # get the coordinates from the sampler state, without units attached
+    >>>
+    >>> # the calculate function will produce information used to calculate the energy
+    >>> n_neighbors, padding_mask, dist, r_ij = pair_list.calculate(coordinates)
+    >>>
+    """
 
     def __init__(
         self,
@@ -208,14 +238,16 @@ class PairsBase(ABC):
         box_vectors: Union[jnp.array, unit.Quantity],
     ):
         """
-        Build the neighborlist from an array of coordinates and box vectors.
+        Build list from an array of coordinates and array of box vectors.
 
         Parameters
         ----------
-        coordinates: jnp.array
-            Shape[N,3] array of particle coordinates
-        box_vectors: jnp.array
-            Shape[3,3] array of box vectors
+        coordinates: jnp.array or unit.Quantity
+            Shape[n_particles,3] array of particle coordinates, either with or without units attached.
+            If the array is passed as a unit.Quantity, the units must be distances and will be converted to nanometers.
+        box_vectors: jnp.array or unit.Quantity
+            Shape[3,3] array of box vectors for the system, either with or without units attached.
+            If the array is passed as a unit.Quantity, the units must be distances and will be converted to nanometers.
 
         Returns
         -------
@@ -224,9 +256,43 @@ class PairsBase(ABC):
         """
         pass
 
+    def _validate_build_inputs(
+        self,
+        coordinates: Union[jnp.array, unit.Quantity],
+        box_vectors: Union[jnp.array, unit.Quantity],
+    ):
+        """
+        Validate the inputs to the build function.
+        """
+        if isinstance(coordinates, unit.Quantity):
+            if not coordinates.unit.is_compatible(unit.nanometer):
+                raise ValueError(
+                    f"Coordinates require distance units, not {coordinates.unit}"
+                )
+            self.ref_coordinates = coordinates.value_in_unit_system(unit.md_unit_system)
+        if isinstance(coordinates, jnp.ndarray):
+            if coordinates.shape[1] != 3:
+                raise ValueError(
+                    f"coordinates should be a Nx3 array, shape provided: {coordinates.shape}"
+                )
+            self.ref_coordinates = coordinates
+        if isinstance(box_vectors, unit.Quantity):
+            if not box_vectors.unit.is_compatible(unit.nanometer):
+                raise ValueError(
+                    f"Box vectors require distance unit, not {box_vectors.unit}"
+                )
+            self.box_vectors = box_vectors.value_in_unit_system(unit.md_unit_system)
+
+        if isinstance(box_vectors, jnp.ndarray):
+            if box_vectors.shape != (3, 3):
+                raise ValueError(
+                    f"box_vectors should be a 3x3 array, shape provided: {box_vectors.shape}"
+                )
+            self.box_vectors = box_vectors
+
     def build_from_state(self, sampler_state: SamplerState):
         """
-        Build the neighbor list from a SamplerState object
+        Build the list from a SamplerState object
 
         Parameters
         ----------
@@ -423,7 +489,7 @@ class NeighborListNsqrd(PairsBase):
         # since this needs to be uniformly sized, we can just fill this array up to the n_max_neighbors.
         neighbor_list = jnp.array(
             jnp.where(neighbor_mask, size=n_max_neighbors, fill_value=fill_value),
-            dtype=jnp.uint16,
+            dtype=jnp.uint32,
         )
         # we need to generate a new mask associatd with the padded neighbor list
         # to be able to quickly exclude the padded values from the neighbor list
@@ -485,7 +551,7 @@ class NeighborListNsqrd(PairsBase):
 
         # store the ids of all the particles
         self.particle_ids = jnp.array(
-            range(0, self.ref_coordinates.shape[0]), dtype=jnp.uint16
+            range(0, self.ref_coordinates.shape[0]), dtype=jnp.uint32
         )
 
         # calculate which pairs to exclude
@@ -588,12 +654,14 @@ class NeighborListNsqrd(PairsBase):
         -------
         n_neighbors: jnp.array
             Array of number of neighbors for each particle
+        neighbor_list: jnp.array
+            Array of particle ids for the neighbors, padded to n_max_neighbors. Shape (n_particles, n_max_neighbors)
         padding_mask: jnp.array
-            Array of masks to exclude padding from the neighbor list of each particle
+            Array of masks to exclude padding from the neighbor list of each particle. Shape (n_particles, n_max_neighbors)
         dist: jnp.array
-            Array of distances between each particle and its neighbors
+            Array of distances between each particle and its neighbors. Shape (n_particles, n_max_neighbors)
         r_ij: jnp.array
-            Array of displacement vectors between each particle and its neighbors
+            Array of displacement vectors between each particle and its neighbors. Shape (n_particles, n_max_neighbors, 3)
         """
         # coordinates = sampler_state.x0
         # note, we assume the box vectors do not change between building and calculating the neighbor list
@@ -603,7 +671,7 @@ class NeighborListNsqrd(PairsBase):
             self._calc_distance_per_particle, in_axes=(0, 0, 0, None)
         )(self.particle_ids, self.neighbor_list, self.neighbor_mask, coordinates)
         # mask = mask.reshape(-1, self.n_max_neighbors)
-        return n_neighbors, padding_mask, dist, r_ij
+        return n_neighbors, self.neighbor_list, padding_mask, dist, r_ij
 
     @partial(jax.jit, static_argnums=(0,))
     def _calculate_particle_displacement(self, particle, coordinates, ref_coordinates):
@@ -740,6 +808,7 @@ class PairList(PairsBase):
         """
         # for the nsq approach, we consider the distance between a particle and all other particles in the system
         # if we used a cell list the possible_neighbors would be a smaller list, i.e., only those in the neigboring cells
+        # we'll just keep with naming syntax for future flexibility
 
         possible_neighbors = particle_ids
 
@@ -747,19 +816,19 @@ class PairList(PairsBase):
             possible_neighbors,
             (particle_ids.shape[0], possible_neighbors.shape[0]),
         )
-
         # reshape the particle_ids
         particles_i = jnp.reshape(particle_ids, (particle_ids.shape[0], 1))
         # create a mask to exclude self interactions and double counting
         temp_mask = particles_i != particles_j
-
         all_pairs = jax.vmap(self._remove_self_interactions, in_axes=(0, 0))(
             particles_j, temp_mask
         )
+        del temp_mask
+        all_pairs = jnp.array(all_pairs[0], dtype=jnp.uint32)
 
-        reduction_mask = jnp.where(particles_i < all_pairs[0], True, False)
+        reduction_mask = jnp.where(particles_i < all_pairs, True, False)
 
-        return all_pairs[0], reduction_mask
+        return all_pairs, reduction_mask
 
     @partial(jax.jit, static_argnums=(0,))
     def _remove_self_interactions(self, particles, temp_mask):
@@ -789,35 +858,17 @@ class PairList(PairsBase):
         """
 
         # set our reference coordinates
-        # the call to x0 and box_vectors automatically convert these to jnp arrays in the correct unit system
-        if isinstance(coordinates, unit.Quantity):
-            if not coordinates.unit.is_compatible(unit.nanometer):
-                raise ValueError(
-                    f"Coordinates require distance units, not {coordinates.unit}"
-                )
-            coordinates = coordinates.value_in_unit_system(unit.md_unit_system)
+        # this will set self.ref_coordinates=coordinates and self.box_vectors
+        self._validate_build_inputs(coordinates, box_vectors)
 
-        if isinstance(box_vectors, unit.Quantity):
-            if not box_vectors.unit.is_compatible(unit.nanometer):
-                raise ValueError(
-                    f"Box vectors require distance unit, not {box_vectors.unit}"
-                )
-            box_vectors = box_vectors.value_in_unit_system(unit.md_unit_system)
-
-        if box_vectors.shape != (3, 3):
-            raise ValueError(
-                f"box_vectors should be a 3x3 array, shape provided: {box_vectors.shape}"
-            )
-
-        self.n_particles = coordinates.shape[0]
-        self.box_vectors = box_vectors
+        self.n_particles = self.ref_coordinates.shape[0]
 
         # the neighborlist assumes that the box vectors do not change between building and calculating the neighbor list
         # changes to the box vectors require rebuilding the neighbor list
         self.space.box_vectors = self.box_vectors
 
         # store the ids of all the particles
-        self.particle_ids = jnp.array(range(0, coordinates.shape[0]), dtype=jnp.uint16)
+        self.particle_ids = jnp.array(range(0, coordinates.shape[0]), dtype=jnp.uint32)
 
         # calculate which pairs to exclude
         self.all_pairs, self.reduction_mask = self._pairs_and_mask(self.particle_ids)
@@ -886,13 +937,15 @@ class PairList(PairsBase):
         Returns
         -------
         n_neighbors: jnp.array
-            Array of number of interacting particles for each particle
+            Array of the number of interacting particles (i.e., where dist < cutoff). Shape: (n_particles)
+        pairs: jnp.array
+            Array of particle ids that were considered for interaction. Shape: (n_particles, n_particles-1)
         padding_mask: jnp.array
-            Array used to masks non interaction particle pairs,
+            Array used to masks non interaction particle pairs. Shape: (n_particles, n_particles-1)
         dist: jnp.array
-            Array of distances between each particle and all other particles in the system
+            Array of distances between pairs in the system. Shape: (n_particles, n_particles-1)
         r_ij: jnp.array
-            Array of displacement vectors between each particle and all other particles in the system.
+            Array of displacement vectors between particle pairs. Shape: (n_particles, n_particles-1, 3).
         """
         if coordinates.shape[0] != self.n_particles:
             raise ValueError(
@@ -906,7 +959,7 @@ class PairList(PairsBase):
             self._calc_distance_per_particle, in_axes=(0, 0, 0, None)
         )(self.particle_ids, self.all_pairs, self.reduction_mask, coordinates)
 
-        return n_neighbors, padding_mask, dist, r_ij
+        return n_neighbors, self.all_pairs, padding_mask, dist, r_ij
 
     def check(self, coordinates: jnp.array) -> bool:
         """

--- a/chiron/potential.py
+++ b/chiron/potential.py
@@ -169,7 +169,7 @@ class LJPotential(NeuralNetworkPotential):
 
         if nbr_list is None:
             log.debug(
-                "nbr_list is None, computing pairlist using N^2 method without PBC."
+                "nbr_list is None, computing  using inefficient N^2 pairlist without PBC."
             )
             # Compute the pairlist for a given set of positions and a cutoff distance
             # Note in this case, we do not need the pairs or displacement vectors

--- a/chiron/potential.py
+++ b/chiron/potential.py
@@ -252,22 +252,19 @@ class LJPotential(NeuralNetworkPotential):
             The forces on the particles in the system
 
         """
-        if nbr_list is None:
-            dist, displacement_vector, pairs = self.compute_pairlist(
-                positions, self.cutoff
-            )
+        dist, displacement_vector, pairs = self.compute_pairlist(positions, self.cutoff)
 
-            forces = (
-                24
-                * (self.epsilon / (dist * dist))
-                * (2 * (self.sigma / dist) ** 12 - (self.sigma / dist) ** 6)
-            ).reshape(-1, 1) * displacement_vector
+        forces = (
+            24
+            * (self.epsilon / (dist * dist))
+            * (2 * (self.sigma / dist) ** 12 - (self.sigma / dist) ** 6)
+        ).reshape(-1, 1) * displacement_vector
 
-            force_array = jnp.zeros((positions.shape[0], 3))
-            for force, p1, p2 in zip(forces, pairs[0], pairs[1]):
-                force_array = force_array.at[p1].add(force)
-                force_array = force_array.at[p2].add(-force)
-            return force_array
+        force_array = jnp.zeros((positions.shape[0], 3))
+        for force, p1, p2 in zip(forces, pairs[0], pairs[1]):
+            force_array = force_array.at[p1].add(force)
+            force_array = force_array.at[p2].add(-force)
+        return force_array
 
 
 class HarmonicOscillatorPotential(NeuralNetworkPotential):

--- a/chiron/potential.py
+++ b/chiron/potential.py
@@ -204,7 +204,7 @@ class LJPotential(NeuralNetworkPotential):
                     f"Neighborlist cutoff ({nbr_list.cutoff}) must be the same as the potential cutoff ({self.cutoff})"
                 )
 
-            n_neighbors, mask, dist, displacement_vectors = nbr_list.calculate(
+            n_neighbors, pairs, mask, dist, displacement_vectors = nbr_list.calculate(
                 positions
             )
 
@@ -235,17 +235,16 @@ class LJPotential(NeuralNetworkPotential):
         return super().compute_force(positions, nbr_list=nbr_list)
 
     def compute_force_analytical(
-        self, positions: jnp.array, nbr_list=None
+        self,
+        positions: jnp.array,
     ) -> jnp.array:
         """
-        Compute the LJ force using the analytical expression.
+        Compute the LJ force using the analytical expression for testing purposes.
 
         Parameters
         ----------
         positions : jnp.array
             The positions of the particles in the system
-        nbr_list : NeighborList, optional
-            Instance of the neighborlist class to use. By default, set to None, which will use an N^2 pairlist
 
         Returns
         -------


### PR DESCRIPTION
## Description
This relates to issue #10 .  The pair and neighborlist classes now also return the index of the pairs.  This information was available, just not returned during the calculate function (as it wasn't necessary for initial testing/dev of a monatomic system). 

Note:  I tried a version of the pairlist that basically just removed non-interacting pairs to reduce the number of atoms used in the force calculation (current code will have all possible pairs, and the energy is just multiplied by either 0 or 1, i.e., based on the mask).   Similar to the neighborlist, there was a n_max_neighbors variable that would pad things out.  For the range of system sizes tested these extra steps took more time than extra LJ computations.  I suspect for an NNP, this step to reduce extra interactions will likely  speed things up given the cost of the NNP.  This will be added in a follow-up commit to this PR; if it is ultimately not useful we can remove later.  I'm not sure if this should be a new class or just part of the same class



## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Make pair information accessible to allow for mixed systems
  - [x] Improve doc strings
  
 Will move the other action items to a separate PR as they are not actually necessary here and not merging will potential block progress in other items. 

>  - [ ] Add in code that reduces and pads the Pairlist 
>   - [ ] Add in example using the minimize function
>   - [ ] Create mixed LJ system to implement logic related to converting topology information into the most usable form.
>   

## Status
- [x] Ready to go