### PR TITLE
Reduced potential update

### DIFF
--- a/Examples/LJ_mcmove.py
+++ b/Examples/LJ_mcmove.py
@@ -59,9 +59,9 @@ from chiron.mcmc import MetropolisDisplacementMove
 
 mc_move = MetropolisDisplacementMove(
     seed=1234,
-    displacement_sigma=0.1 * unit.nanometer,
-    nr_of_moves=10,
+    displacement_sigma=0.01 * unit.nanometer,
+    nr_of_moves=1000,
     simulation_reporter=reporter,
 )
 
-mc_move.run(sampler_state, thermodynamic_state, True)
+mc_move.run(sampler_state, thermodynamic_state, nbr_list, True)

--- a/Examples/LJ_mcmove.py
+++ b/Examples/LJ_mcmove.py
@@ -1,0 +1,67 @@
+from openmmtools.testsystems import LennardJonesFluid
+
+# Use the LennardJonesFluid example from openmmtools to initialize particle positions and topology
+# For this example, the topology provides the masses for the particles
+# The default LennardJonesFluid example considers the system to be Argon with 39.9 amu
+lj_fluid = LennardJonesFluid(reduced_density=0.1, nparticles=1000)
+
+
+from chiron.potential import LJPotential
+from openmm import unit
+
+# initialize the LennardJones potential in chiron
+#
+sigma = 0.34 * unit.nanometer
+epsilon = 0.238 * unit.kilocalories_per_mole
+cutoff = 3.0 * sigma
+
+lj_potential = LJPotential(
+    lj_fluid.topology, sigma=sigma, epsilon=epsilon, cutoff=cutoff
+)
+
+from chiron.states import SamplerState, ThermodynamicState
+
+# define the sampler state
+sampler_state = SamplerState(
+    x0=lj_fluid.positions, box_vectors=lj_fluid.system.getDefaultPeriodicBoxVectors()
+)
+
+# define the thermodynamic state
+thermodynamic_state = ThermodynamicState(
+    potential=lj_potential, temperature=300 * unit.kelvin
+)
+
+from chiron.neighbors import NeighborListNsqrd, OrthogonalPeriodicSpace
+
+# define the neighbor list for an orthogonal periodic space
+skin = 0.5 * unit.nanometer
+
+nbr_list = NeighborListNsqrd(
+    OrthogonalPeriodicSpace(), cutoff=cutoff, skin=skin, n_max_neighbors=180
+)
+from chiron.neighbors import PairList
+
+
+# build the neighbor list from the sampler state
+nbr_list.build_from_state(sampler_state)
+
+from chiron.reporters import SimulationReporter
+
+# initialize a reporter to save the simulation data
+filename = "test_lj.h5"
+import os
+
+if os.path.isfile(filename):
+    os.remove(filename)
+reporter = SimulationReporter("test_mc_lj.h5", lj_fluid.topology, 1)
+
+from chiron.mcmc import MetropolisDisplacementMove
+
+mc_move = MetropolisDisplacementMove(
+    seed=1234,
+    displacement_sigma=0.1 * unit.nanometer,
+    nr_of_moves=10,
+    simulation_reporter=reporter,
+)
+
+mc_move.run(sampler_state, thermodynamic_state, True)

--- a/chiron/states.py
+++ b/chiron/states.py
@@ -30,9 +30,7 @@ class SamplerState:
         # NOTE: all units are internally in the openMM units system as documented here:
         # http://docs.openmm.org/latest/userguide/theory/01_introduction.html#units
         if not isinstance(x0, unit.Quantity):
-            raise TypeError(
-                f"x0 must be a unit.Quantity, got {type(x0)} instead."
-            )
+            raise TypeError(f"x0 must be a unit.Quantity, got {type(x0)} instead.")
         if velocities is not None and not isinstance(velocities, unit.Quantity):
             raise TypeError(
                 f"velocities must be a unit.Quantity, got {type(velocities)} instead."
@@ -42,17 +40,13 @@ class SamplerState:
                 try:
                     box_vectors = self._convert_from_openmm_box(box_vectors)
                 except:
-                    raise TypeError(
-                        f"Unable to parse box_vectors {box_vectors}."
-                    )
+                    raise TypeError(f"Unable to parse box_vectors {box_vectors}.")
             else:
                 raise TypeError(
                     f"box_vectors must be a unit.Quantity or openMM box, got {type(box_vectors)} instead."
                 )
         if not x0.unit.is_compatible(unit.nanometer):
-            raise ValueError(
-                f"x0 must have units of distance, got {x0.unit} instead."
-            )
+            raise ValueError(f"x0 must have units of distance, got {x0.unit} instead.")
         if velocities is not None and not velocities.unit.is_compatible(
             unit.nanometer / unit.picosecond
         ):
@@ -74,7 +68,6 @@ class SamplerState:
         self._velocities = velocities
         self._box_vectors = box_vectors
         self._distance_unit = unit.nanometer
-
 
     @property
     def x0(self) -> jnp.array:
@@ -112,13 +105,14 @@ class SamplerState:
         array_ = array.value_in_unit_system(unit.md_unit_system)
         return jnp.array(array_)
 
-    def _convert_from_openmm_box(self, openmm_box_vectors:List)->unit.Quantity:
-
+    def _convert_from_openmm_box(self, openmm_box_vectors: List) -> unit.Quantity:
         box_vec = []
         for i in range(0, 3):
             layer = []
             for j in range(0, 3):
-                layer.append(openmm_box_vectors[i][j].value_in_unit(openmm_box_vectors[0].unit))
+                layer.append(
+                    openmm_box_vectors[i][j].value_in_unit(openmm_box_vectors[0].unit)
+                )
             box_vec.append(layer)
         return unit.Quantity(jnp.array(box_vec), openmm_box_vectors[0].unit)
 
@@ -148,13 +142,33 @@ class ThermodynamicState:
         pressure: Optional[unit.Quantity] = None,
     ):
         self.potential = potential
-        self.temperature = temperature
-        if temperature:
-            self.beta = 1.0 / (
-                unit.BOLTZMANN_CONSTANT_kB * (self.temperature * unit.kelvin)
+
+        if temperature is not None and not isinstance(temperature, unit.Quantity):
+            raise TypeError(
+                f"temperature must be a unit.Quantity, got {type(temperature)} instead."
             )
         else:
+            if not temperature.unit.is_compatible(unit.kelvin):
+                raise ValueError(
+                    f"temperature must have units of temperature, got {temperature.unit} instead."
+                )
+
+        if volume is not None and not isinstance(volume, unit.Quantity):
+            raise TypeError(
+                f"volume must be a unit.Quantity, got {type(volume)} instead."
+            )
+        else:
+            if not volume.unit.is_compatible(unit.nanometer**3):
+                raise ValueError(
+                    f"volume must have units of distance**3, got {volume.unit} instead."
+                )
+
+        self.temperature = temperature
+        if temperature is not None:
+            self.beta = 1.0 / (unit.BOLTZMANN_CONSTANT_kB * (self.temperature))
+        else:
             self.beta = None
+
         self.volume = volume
         self.pressure = pressure
 

--- a/chiron/states.py
+++ b/chiron/states.py
@@ -147,7 +147,7 @@ class ThermodynamicState:
             raise TypeError(
                 f"temperature must be a unit.Quantity, got {type(temperature)} instead."
             )
-        else:
+        elif temperature is not None:
             if not temperature.unit.is_compatible(unit.kelvin):
                 raise ValueError(
                     f"temperature must have units of temperature, got {temperature.unit} instead."
@@ -157,7 +157,7 @@ class ThermodynamicState:
             raise TypeError(
                 f"volume must be a unit.Quantity, got {type(volume)} instead."
             )
-        else:
+        elif volume is not None:
             if not volume.unit.is_compatible(unit.nanometer**3):
                 raise ValueError(
                     f"volume must have units of distance**3, got {volume.unit} instead."

--- a/chiron/states.py
+++ b/chiron/states.py
@@ -236,7 +236,9 @@ class ThermodynamicState:
         """
         pass
 
-    def get_reduced_potential(self, sampler_state: SamplerState) -> float:
+    def get_reduced_potential(
+        self, sampler_state: SamplerState, nbr_list=None
+    ) -> float:
         """
         Compute the reduced potential for the given sampler state.
 
@@ -244,6 +246,8 @@ class ThermodynamicState:
         ----------
         sampler_state : SamplerState
             The sampler state for which to compute the reduced potential.
+        nbr_list : NeighborList or PairList, optional
+            The neighbor list or pair list routine to use for calculating the reduced potential.
 
         Returns
         -------
@@ -266,7 +270,8 @@ class ThermodynamicState:
         log.debug(f"sample state: {sampler_state.x0}")
         reduced_potential = (
             unit.Quantity(
-                self.potential.compute_energy(sampler_state.x0), unit.kilojoule_per_mole
+                self.potential.compute_energy(sampler_state.x0, nbr_list),
+                unit.kilojoule_per_mole,
             )
         ) / unit.AVOGADRO_CONSTANT_NA
         log.debug(f"reduced potential: {reduced_potential}")

--- a/chiron/states.py
+++ b/chiron/states.py
@@ -162,6 +162,15 @@ class ThermodynamicState:
                 raise ValueError(
                     f"volume must have units of distance**3, got {volume.unit} instead."
                 )
+        if pressure is not None and not isinstance(pressure, unit.Quantity):
+            raise TypeError(
+                f"pressure must be a unit.Quantity, got {type(pressure)} instead."
+            )
+        elif pressure is not None:
+            if not pressure.unit.is_compatible(unit.atmosphere):
+                raise ValueError(
+                    f"pressure must have units of pressure, got {pressure.unit} instead."
+                )
 
         self.temperature = temperature
         if temperature is not None:

--- a/chiron/tests/test_integrators.py
+++ b/chiron/tests/test_integrators.py
@@ -1,10 +1,12 @@
 import pytest
 
+
 @pytest.fixture(scope="session")
 def prep_temp_dir(tmpdir_factory):
     """Create a temporary directory for the test."""
     tmpdir = tmpdir_factory.mktemp("test_langevin")
     return tmpdir
+
 
 def test_langevin_dynamics(prep_temp_dir, provide_testsystems_and_potentials):
     """
@@ -13,7 +15,7 @@ def test_langevin_dynamics(prep_temp_dir, provide_testsystems_and_potentials):
     This function initializes openmmtools.testsystems,
     sets up a potential, and uses the Langevin integrator to run the simulation.
     """
-    from openmm.unit import kelvin
+    from openmm import unit
 
     i = 0
     for testsystem, potential in provide_testsystems_and_potentials:
@@ -24,7 +26,7 @@ def test_langevin_dynamics(prep_temp_dir, provide_testsystems_and_potentials):
         from chiron.states import SamplerState, ThermodynamicState
 
         thermodynamic_state = ThermodynamicState(
-            potential=potential, temperature=300 * kelvin
+            potential=potential, temperature=300 * unit.kelvin
         )
 
         sampler_state = SamplerState(testsystem.positions)

--- a/chiron/tests/test_mcmc.py
+++ b/chiron/tests/test_mcmc.py
@@ -101,7 +101,9 @@ def test_sample_from_harmonic_osciallator_with_MCMC_classes_and_LangevinDynamics
     from chiron.states import ThermodynamicState, SamplerState
 
     thermodynamic_state = ThermodynamicState(
-        harmonic_potential, temperature=300, volume=30 * (unit.angstrom**3)
+        harmonic_potential,
+        temperature=300 * unit.kelvin,
+        volume=30 * (unit.angstrom**3),
     )
     sampler_state = SamplerState(ho.positions)
 
@@ -151,7 +153,9 @@ def test_sample_from_harmonic_osciallator_with_MCMC_classes_and_MetropolisDispla
     from chiron.states import ThermodynamicState, SamplerState
 
     thermodynamic_state = ThermodynamicState(
-        harmonic_potential, temperature=300, volume=30 * (unit.angstrom**3)
+        harmonic_potential,
+        temperature=300 * unit.kelvin,
+        volume=30 * (unit.angstrom**3),
     )
     sampler_state = SamplerState(ho.positions)
 
@@ -204,7 +208,9 @@ def test_sample_from_harmonic_osciallator_array_with_MCMC_classes_and_Metropolis
     from chiron.states import ThermodynamicState, SamplerState
 
     thermodynamic_state = ThermodynamicState(
-        harmonic_potential, temperature=300, volume=30 * (unit.angstrom**3)
+        harmonic_potential,
+        temperature=300 * unit.kelvin,
+        volume=30 * (unit.angstrom**3),
     )
     sampler_state = SamplerState(ho.positions)
 
@@ -229,6 +235,23 @@ def test_sample_from_harmonic_osciallator_array_with_MCMC_classes_and_Metropolis
 
     # Run the sampler with the thermodynamic state and sampler state and return the sampler state
     sampler.run(n_iterations=2)  # how many times to repeat
+
+
+def test_thermodynamic_state_inputs():
+    with pytest.raises(TypeError):
+        ThermodynamicState(potential=None, temperature=300)
+
+    with pytest.raises(ValueError):
+        ThermodynamicState(potential=None, temperature=300 * unit.angstrom)
+
+    ThermodynamicState(potential=None, temperature=300 * unit.kelvin)
+
+    with pytest.raises(TypeError):
+        ThermodynamicState(potential=None, volume=1000)
+    with pytest.raises(ValueError):
+        ThermodynamicState(potential=None, volume=1000 * unit.kelvin)
+
+    ThermodynamicState(potential=None, volume=1000 * (unit.angstrom**3))
 
 
 def test_sample_from_joint_distribution_of_two_HO_with_local_moves_and_MC_updates():

--- a/chiron/tests/test_mcmc.py
+++ b/chiron/tests/test_mcmc.py
@@ -238,20 +238,33 @@ def test_sample_from_harmonic_osciallator_array_with_MCMC_classes_and_Metropolis
 
 
 def test_thermodynamic_state_inputs():
+    from chiron.states import ThermodynamicState
+    from openmm import unit
+    from openmmtools.testsystems import HarmonicOscillatorArray
+
+    ho = HarmonicOscillatorArray()
+
+    # Initalize the potential
+    from chiron.potential import HarmonicOscillatorPotential
+
+    harmonic_potential = HarmonicOscillatorPotential(ho.topology, ho.K)
+
     with pytest.raises(TypeError):
-        ThermodynamicState(potential=None, temperature=300)
+        ThermodynamicState(potential=harmonic_potential, temperature=300)
 
     with pytest.raises(ValueError):
-        ThermodynamicState(potential=None, temperature=300 * unit.angstrom)
+        ThermodynamicState(
+            potential=harmonic_potential, temperature=300 * unit.angstrom
+        )
 
-    ThermodynamicState(potential=None, temperature=300 * unit.kelvin)
+    ThermodynamicState(potential=harmonic_potential, temperature=300 * unit.kelvin)
 
     with pytest.raises(TypeError):
-        ThermodynamicState(potential=None, volume=1000)
+        ThermodynamicState(potential=harmonic_potential, volume=1000)
     with pytest.raises(ValueError):
-        ThermodynamicState(potential=None, volume=1000 * unit.kelvin)
+        ThermodynamicState(potential=harmonic_potential, volume=1000 * unit.kelvin)
 
-    ThermodynamicState(potential=None, volume=1000 * (unit.angstrom**3))
+    ThermodynamicState(potential=harmonic_potential, volume=1000 * (unit.angstrom**3))
 
 
 def test_sample_from_joint_distribution_of_two_HO_with_local_moves_and_MC_updates():

--- a/chiron/tests/test_mcmc.py
+++ b/chiron/tests/test_mcmc.py
@@ -266,6 +266,14 @@ def test_thermodynamic_state_inputs():
 
     ThermodynamicState(potential=harmonic_potential, volume=1000 * (unit.angstrom**3))
 
+    with pytest.raises(TypeError):
+        ThermodynamicState(potential=harmonic_potential, pressure=100)
+
+    with pytest.raises(ValueError):
+        ThermodynamicState(potential=harmonic_potential, pressure=100 * unit.kelvin)
+
+    ThermodynamicState(potential=harmonic_potential, pressure=100 * unit.atmosphere)
+
 
 def test_sample_from_joint_distribution_of_two_HO_with_local_moves_and_MC_updates():
     # define two harmonic oscillators with different spring constants and equilibrium positions

--- a/chiron/tests/test_states.py
+++ b/chiron/tests/test_states.py
@@ -18,9 +18,9 @@ def test_initialize_state():
     assert thermodynamic_state.potential is not None
 
     state = ThermodynamicState(
-        potential, temperature=300, volume=30 * (unit.angstrom**3)
+        potential, temperature=300 * unit.kelvin, volume=30 * (unit.angstrom**3)
     )
-    assert state.temperature == 300
+    assert state.temperature == 300 * unit.kelvin
     assert state.pressure is None
     assert state.volume == 30 * (unit.angstrom**3)
     assert state.nr_of_particles == 1
@@ -60,6 +60,7 @@ def test_sampler_state_conversion():
         jnp.array([[1.0, 1.0, 1.0]]),
     )
 
+
 def test_sampler_state_inputs():
     from chiron.states import SamplerState
     from openmm import unit
@@ -69,41 +70,74 @@ def test_sampler_state_inputs():
     # test input of positions
     # should have units
     with pytest.raises(TypeError):
-        SamplerState(x0=jnp.array([1,2,3]))
+        SamplerState(x0=jnp.array([1, 2, 3]))
     # throw and error because of incompatible units
     with pytest.raises(ValueError):
-        SamplerState(x0=unit.Quantity(jnp.array([[1,2,3]]), unit.radians))
+        SamplerState(x0=unit.Quantity(jnp.array([[1, 2, 3]]), unit.radians))
 
     # test input of velocities
     # velocities should have units
     with pytest.raises(TypeError):
-        SamplerState(x0=unit.Quantity(jnp.array([[1,2,3]]), unit.nanometers), velocities=jnp.array([1,2,3]))
+        SamplerState(
+            x0=unit.Quantity(jnp.array([[1, 2, 3]]), unit.nanometers),
+            velocities=jnp.array([1, 2, 3]),
+        )
     # velocities should have units of distance/time
     with pytest.raises(ValueError):
-        SamplerState(x0=unit.Quantity(jnp.array([[1, 2, 3]]), unit.nanometers),  velocities=unit.Quantity(jnp.array([1,2,3]), unit.nanometers))
+        SamplerState(
+            x0=unit.Quantity(jnp.array([[1, 2, 3]]), unit.nanometers),
+            velocities=unit.Quantity(jnp.array([1, 2, 3]), unit.nanometers),
+        )
 
     # test input of box_vectors
     # box_vectors should have units
     with pytest.raises(TypeError):
-        SamplerState(x0=unit.Quantity(jnp.array([[1,2,3]]), unit.nanometers), box_vectors=jnp.array([1,2,3]))
+        SamplerState(
+            x0=unit.Quantity(jnp.array([[1, 2, 3]]), unit.nanometers),
+            box_vectors=jnp.array([1, 2, 3]),
+        )
     # box_vectors should have units of distance
     with pytest.raises(ValueError):
-        SamplerState(x0=unit.Quantity(jnp.array([[1,2,3]]), unit.nanometers), box_vectors=unit.Quantity(jnp.array([[1,0,0], [0,1,0], [0,0,1]]), unit.radians))
-    #check to see that the size of the box vectors are correct
+        SamplerState(
+            x0=unit.Quantity(jnp.array([[1, 2, 3]]), unit.nanometers),
+            box_vectors=unit.Quantity(
+                jnp.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]), unit.radians
+            ),
+        )
+    # check to see that the size of the box vectors are correct
     with pytest.raises(ValueError):
-        SamplerState(x0=unit.Quantity(jnp.array([[1,2,3]]), unit.nanometers), box_vectors=unit.Quantity(jnp.array([[1,0,0], [0,1,0]]), unit.nanometers))
+        SamplerState(
+            x0=unit.Quantity(jnp.array([[1, 2, 3]]), unit.nanometers),
+            box_vectors=unit.Quantity(
+                jnp.array([[1, 0, 0], [0, 1, 0]]), unit.nanometers
+            ),
+        )
 
-    openmm_box = [unit.Quantity([4.031145745088737, 0.0, 0.0], unit.nanometer),
-                  unit.Quantity([0.0, 4.031145745088737, 0.0], unit.nanometer),
-                unit.Quantity([0.0, 0.0, 4.031145745088737],unit.nanometer)]
+    openmm_box = [
+        unit.Quantity([4.031145745088737, 0.0, 0.0], unit.nanometer),
+        unit.Quantity([0.0, 4.031145745088737, 0.0], unit.nanometer),
+        unit.Quantity([0.0, 0.0, 4.031145745088737], unit.nanometer),
+    ]
 
-    #check openmm_box conversion:
-    state = SamplerState(x0=unit.Quantity(jnp.array([[1,2,3]]), unit.nanometers), box_vectors=openmm_box)
-    assert jnp.all(state.box_vectors == jnp.array([[4.0311456, 0.,        0.       ],[0.,        4.0311456, 0.       ],[0.,        0.,        4.0311456]]))
+    # check openmm_box conversion:
+    state = SamplerState(
+        x0=unit.Quantity(jnp.array([[1, 2, 3]]), unit.nanometers),
+        box_vectors=openmm_box,
+    )
+    assert jnp.all(
+        state.box_vectors
+        == jnp.array(
+            [[4.0311456, 0.0, 0.0], [0.0, 4.0311456, 0.0], [0.0, 0.0, 4.0311456]]
+        )
+    )
 
     # openmm box vectors end up as a list with contents; check to make sure we capture an error if we pass a bad list
     with pytest.raises(TypeError):
-        SamplerState(x0=unit.Quantity(jnp.array([[1,2,3]]), unit.nanometers), box_vectors=[123])
+        SamplerState(
+            x0=unit.Quantity(jnp.array([[1, 2, 3]]), unit.nanometers), box_vectors=[123]
+        )
+
+
 def test_reduced_potential():
     """Test the reduced potential function."""
     from chiron.states import ThermodynamicState, SamplerState
@@ -116,7 +150,7 @@ def test_reduced_potential():
     potential = HarmonicOscillatorPotential(topology=ho.topology, k=ho.K, U0=ho.U0)
 
     state = ThermodynamicState(
-        potential, temperature=300, volume=30 * (unit.angstrom**3)
+        potential, temperature=300 * unit.kelvin, volume=30 * (unit.angstrom**3)
     )
     sampler_state = SamplerState(ho.positions)
 


### PR DESCRIPTION
## Description
This refers to issue #12 .  Units were being attached inside of the thermodynamic state init function to temperature; thus if temperature was passed as a unit quantity, the code would fail. 

This PR adds in validation of the inputs and will raise an exception if units are not attached or have the incompatible units.  

## Questions
- [ ] Should number of moves be moved to the run function, to match Langevin? 
## Status
- [x] Ready to go