### PR TITLE
Montecarlo barostat

### DIFF
--- a/Examples/LJ_MCMC.py
+++ b/Examples/LJ_MCMC.py
@@ -1,0 +1,128 @@
+from openmmtools.testsystems import LennardJonesFluid
+
+# Use the LennardJonesFluid example from openmmtools to initialize particle positions and topology
+# For this example, the topology provides the masses for the particles
+# The default LennardJonesFluid example considers the system to be Argon with 39.9 amu
+lj_fluid = LennardJonesFluid(reduced_density=0.005, nparticles=1000)
+
+
+from chiron.potential import LJPotential
+from openmm import unit
+
+# initialize the LennardJones potential in chiron
+#
+sigma = 0.34 * unit.nanometer
+epsilon = 0.238 * unit.kilocalories_per_mole
+cutoff = 3.0 * sigma
+
+lj_potential = LJPotential(
+    lj_fluid.topology, sigma=sigma, epsilon=epsilon, cutoff=cutoff
+)
+
+from chiron.states import SamplerState, ThermodynamicState
+
+# define the sampler state
+sampler_state = SamplerState(
+    x0=lj_fluid.positions, box_vectors=lj_fluid.system.getDefaultPeriodicBoxVectors()
+)
+
+# define the thermodynamic state
+thermodynamic_state = ThermodynamicState(
+    potential=lj_potential,
+    temperature=300 * unit.kelvin,
+    pressure=0.5 * unit.atmosphere,
+)
+
+from chiron.neighbors import NeighborListNsqrd, OrthogonalPeriodicSpace
+
+# define the neighbor list for an orthogonal periodic space
+skin = 0.5 * unit.nanometer
+
+nbr_list = NeighborListNsqrd(
+    OrthogonalPeriodicSpace(), cutoff=cutoff, skin=skin, n_max_neighbors=180
+)
+
+
+# build the neighbor list from the sampler state
+nbr_list.build_from_state(sampler_state)
+
+from chiron.reporters import SimulationReporter
+
+# initialize a reporter to save the simulation data
+filename1 = "test_lj_mc.h5"
+filename2 = "test_lj_langevin.h5"
+import os
+
+if os.path.isfile(filename1):
+    os.remove(filename1)
+if os.path.isfile(filename2):
+    os.remove(filename2)
+reporter1 = SimulationReporter(filename1, lj_fluid.topology, 10)
+reporter2 = SimulationReporter(filename2, lj_fluid.topology, 10)
+
+from chiron.mcmc import (
+    MetropolisDisplacementMove,
+    MoveSet,
+    MCMCSampler,
+    MCBarostatMove,
+    LangevinDynamicsMove,
+)
+
+langevin_move = LangevinDynamicsMove(
+    stepsize=1.0 * unit.femtoseconds,
+    collision_rate=1.0 / unit.picoseconds,
+    nr_of_steps=1000,
+    simulation_reporter=reporter2,
+    seed=1234,
+)
+
+mc_disp_move = MetropolisDisplacementMove(
+    seed=1234,
+    displacement_sigma=0.01 * unit.nanometer,
+    nr_of_moves=1000,
+    simulation_reporter=reporter1,
+)
+
+mc_barostat_move = MCBarostatMove(
+    seed=1234,
+    volume_max_scale=0.01,
+    nr_of_moves=100,
+    simulation_reporter=reporter1,
+)
+move_set = MoveSet(
+    [
+        ("MetropolisDisplacementMove", mc_disp_move),
+        ("LangevinMove", langevin_move),
+        ("MCBarostatMove", mc_barostat_move),
+    ]
+)
+
+sampler = MCMCSampler(move_set, sampler_state, thermodynamic_state)
+
+mass = unit.Quantity(39.948, unit.gram / unit.mole)
+volume = (
+    sampler_state.box_vectors[0][0]
+    * sampler_state.box_vectors[1][1]
+    * sampler_state.box_vectors[2][2]
+)
+initial_density = (
+    mass
+    * sampler.sampler_state.x0.shape[0]
+    / unit.AVOGADRO_CONSTANT_NA
+    / (unit.Quantity(volume, unit.nanometer**3))
+)
+
+sampler.run(n_iterations=100, nbr_list=nbr_list)  # how many times to repeat
+
+final_density = (
+    mass
+    * sampler.sampler_state.x0.shape[0]
+    / unit.AVOGADRO_CONSTANT_NA
+    / (sampler.thermodynamic_state.volume)
+)
+print(f"initial density: {initial_density}\nfinal density: {final_density}")
+print(
+    f"initial density: {initial_density.value_in_unit(unit.kilogram/unit.meter**3)}\nfinal density: {final_density.value_in_unit(unit.kilogram/unit.meter**3)}"
+)
+print(mc_barostat_move.statistics)
+print(mc_disp_move.statistics)

--- a/Examples/LJ_MCMC.py
+++ b/Examples/LJ_MCMC.py
@@ -3,17 +3,17 @@ from openmmtools.testsystems import LennardJonesFluid
 # Use the LennardJonesFluid example from openmmtools to initialize particle positions and topology
 # For this example, the topology provides the masses for the particles
 # The default LennardJonesFluid example considers the system to be Argon with 39.9 amu
-lj_fluid = LennardJonesFluid(reduced_density=0.005, nparticles=1000)
+lj_fluid = LennardJonesFluid(reduced_density=0.5, nparticles=1100)
 
 
 from chiron.potential import LJPotential
 from openmm import unit
 
-# initialize the LennardJones potential in chiron
+# initialize the LennardJones potential for UA-TraPPE methane
 #
-sigma = 0.34 * unit.nanometer
-epsilon = 0.238 * unit.kilocalories_per_mole
-cutoff = 3.0 * sigma
+sigma = 0.373 * unit.nanometer
+epsilon = 0.2941 * unit.kilocalories_per_mole
+cutoff = 1.4 * unit.nanometer
 
 lj_potential = LJPotential(
     lj_fluid.topology, sigma=sigma, epsilon=epsilon, cutoff=cutoff
@@ -29,36 +29,47 @@ sampler_state = SamplerState(
 # define the thermodynamic state
 thermodynamic_state = ThermodynamicState(
     potential=lj_potential,
-    temperature=300 * unit.kelvin,
-    pressure=0.5 * unit.atmosphere,
+    temperature=140 * unit.kelvin,
+    pressure=13.00765 * unit.atmosphere,
 )
 
-from chiron.neighbors import NeighborListNsqrd, OrthogonalPeriodicSpace
+from chiron.neighbors import PairList, OrthogonalPeriodicSpace
 
 # define the neighbor list for an orthogonal periodic space
 skin = 0.5 * unit.nanometer
 
-nbr_list = NeighborListNsqrd(
-    OrthogonalPeriodicSpace(), cutoff=cutoff, skin=skin, n_max_neighbors=180
-)
+nbr_list = PairList(OrthogonalPeriodicSpace(), cutoff=cutoff)
 
 
 # build the neighbor list from the sampler state
 nbr_list.build_from_state(sampler_state)
 
+from chiron.minimze import minimize_energy
+
+results = minimize_energy(
+    sampler_state.x0, lj_potential.compute_energy, nbr_list, maxiter=100
+)
+
+min_x = results.params
+
+
 from chiron.reporters import SimulationReporter
 
 # initialize a reporter to save the simulation data
-filename1 = "test_lj_mc.h5"
-filename2 = "test_lj_langevin.h5"
+filename1 = "test_lj_nvt.h5"
+filename2 = "test_lj_npt.h5"
+filename3 = "test_lj_langevin.h5"
 import os
 
 if os.path.isfile(filename1):
     os.remove(filename1)
 if os.path.isfile(filename2):
     os.remove(filename2)
+if os.path.isfile(filename3):
+    os.remove(filename3)
 reporter1 = SimulationReporter(filename1, lj_fluid.topology, 10)
 reporter2 = SimulationReporter(filename2, lj_fluid.topology, 10)
+reporter3 = SimulationReporter(filename3, lj_fluid.topology, 10)
 
 from chiron.mcmc import (
     MetropolisDisplacementMove,
@@ -72,34 +83,34 @@ langevin_move = LangevinDynamicsMove(
     stepsize=1.0 * unit.femtoseconds,
     collision_rate=1.0 / unit.picoseconds,
     nr_of_steps=1000,
-    simulation_reporter=reporter2,
+    simulation_reporter=reporter3,
     seed=1234,
 )
 
 mc_disp_move = MetropolisDisplacementMove(
     seed=1234,
-    displacement_sigma=0.01 * unit.nanometer,
-    nr_of_moves=1000,
+    displacement_sigma=0.005 * unit.nanometer,
+    nr_of_moves=90,
     simulation_reporter=reporter1,
 )
 
 mc_barostat_move = MCBarostatMove(
     seed=1234,
     volume_max_scale=0.01,
-    nr_of_moves=100,
-    simulation_reporter=reporter1,
+    nr_of_moves=10,
+    simulation_reporter=reporter2,
 )
 move_set = MoveSet(
     [
         ("MetropolisDisplacementMove", mc_disp_move),
-        ("LangevinMove", langevin_move),
+        # ("LangevinMove", langevin_move),
         ("MCBarostatMove", mc_barostat_move),
     ]
 )
 
 sampler = MCMCSampler(move_set, sampler_state, thermodynamic_state)
 
-mass = unit.Quantity(39.948, unit.gram / unit.mole)
+mass = unit.Quantity(16.04, unit.gram / unit.mole)
 volume = (
     sampler_state.box_vectors[0][0]
     * sampler_state.box_vectors[1][1]
@@ -111,8 +122,9 @@ initial_density = (
     / unit.AVOGADRO_CONSTANT_NA
     / (unit.Quantity(volume, unit.nanometer**3))
 )
-
-sampler.run(n_iterations=100, nbr_list=nbr_list)  # how many times to repeat
+densities = []
+densities.append(initial_density)
+sampler.run(n_iterations=20000, nbr_list=nbr_list)  # how many times to repeat
 
 final_density = (
     mass
@@ -120,6 +132,8 @@ final_density = (
     / unit.AVOGADRO_CONSTANT_NA
     / (sampler.thermodynamic_state.volume)
 )
+densities.append(final_density)
+
 print(f"initial density: {initial_density}\nfinal density: {final_density}")
 print(
     f"initial density: {initial_density.value_in_unit(unit.kilogram/unit.meter**3)}\nfinal density: {final_density.value_in_unit(unit.kilogram/unit.meter**3)}"

--- a/Examples/LJ_MCMC.py
+++ b/Examples/LJ_MCMC.py
@@ -89,21 +89,22 @@ langevin_move = LangevinDynamicsMove(
 
 mc_disp_move = MetropolisDisplacementMove(
     seed=1234,
-    displacement_sigma=0.005 * unit.nanometer,
+    displacement_sigma=0.1 * unit.nanometer,
     nr_of_moves=90,
     simulation_reporter=reporter1,
 )
 
 mc_barostat_move = MCBarostatMove(
     seed=1234,
-    volume_max_scale=0.01,
+    volume_max_scale=0.1,
     nr_of_moves=10,
+    adjust_box_scaling=True,
+    adjust_frequency=100,
     simulation_reporter=reporter2,
 )
 move_set = MoveSet(
     [
         ("MetropolisDisplacementMove", mc_disp_move),
-        # ("LangevinMove", langevin_move),
         ("MCBarostatMove", mc_barostat_move),
     ]
 )

--- a/Examples/LJ_MCMC.py
+++ b/Examples/LJ_MCMC.py
@@ -124,7 +124,7 @@ initial_density = (
 )
 densities = []
 densities.append(initial_density)
-sampler.run(n_iterations=20000, nbr_list=nbr_list)  # how many times to repeat
+sampler.run(n_iterations=100, nbr_list=nbr_list)  # how many times to repeat
 
 final_density = (
     mass

--- a/Examples/LJ_mcbarostat.py
+++ b/Examples/LJ_mcbarostat.py
@@ -1,0 +1,70 @@
+from openmmtools.testsystems import LennardJonesFluid
+
+# Use the LennardJonesFluid example from openmmtools to initialize particle positions and topology
+# For this example, the topology provides the masses for the particles
+# The default LennardJonesFluid example considers the system to be Argon with 39.9 amu
+lj_fluid = LennardJonesFluid(reduced_density=0.1, nparticles=1000)
+
+
+from chiron.potential import LJPotential
+from openmm import unit
+
+# initialize the LennardJones potential in chiron
+#
+sigma = 0.34 * unit.nanometer
+epsilon = 0.238 * unit.kilocalories_per_mole
+cutoff = 3.0 * sigma
+
+lj_potential = LJPotential(
+    lj_fluid.topology, sigma=sigma, epsilon=epsilon, cutoff=cutoff
+)
+
+from chiron.states import SamplerState, ThermodynamicState
+
+# define the sampler state
+sampler_state = SamplerState(
+    x0=lj_fluid.positions, box_vectors=lj_fluid.system.getDefaultPeriodicBoxVectors()
+)
+
+# define the thermodynamic state
+thermodynamic_state = ThermodynamicState(
+    potential=lj_potential,
+    temperature=300 * unit.kelvin,
+    pressure=1.0 * unit.atmosphere,
+)
+
+from chiron.neighbors import NeighborListNsqrd, OrthogonalPeriodicSpace
+
+# define the neighbor list for an orthogonal periodic space
+skin = 0.5 * unit.nanometer
+
+nbr_list = NeighborListNsqrd(
+    OrthogonalPeriodicSpace(), cutoff=cutoff, skin=skin, n_max_neighbors=180
+)
+from chiron.neighbors import PairList
+
+
+# build the neighbor list from the sampler state
+nbr_list.build_from_state(sampler_state)
+
+from chiron.reporters import SimulationReporter
+
+# initialize a reporter to save the simulation data
+filename = "test_lj.h5"
+import os
+
+if os.path.isfile(filename):
+    os.remove(filename)
+reporter = SimulationReporter("test_mc_lj.h5", lj_fluid.topology, 1)
+
+print(thermodynamic_state.pressure)
+from chiron.mcmc import MCBarostatMove
+
+barostat_move = MCBarostatMove(
+    seed=1234,
+    volume_max_scale=0.01,
+    nr_of_moves=1000,
+    simulation_reporter=reporter,
+)
+
+barostat_move.run(sampler_state, thermodynamic_state, nbr_list, True)

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
 MIT License
 
-Copyright (c) 2023 Chris Iacovella
+Copyright (c) 2023 Chodera Lab
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/chiron/mcmc.py
+++ b/chiron/mcmc.py
@@ -422,6 +422,8 @@ class MetropolizedMove(MCMove):
                 proposed_positions
             )
         if nbr_list is not None:
+            sampler_state.x0 = nbr_list.space.wrap(sampler_state.x0)
+
             if nbr_list.check(sampler_state.x0):
                 nbr_list.build(sampler_state.x0, sampler_state.box_vectors)
 

--- a/chiron/mcmc.py
+++ b/chiron/mcmc.py
@@ -487,6 +487,10 @@ class MetropolizedMove(MCMove):
                 sampler_state.x0 = sampler_state.x0.at[jnp.array([atom_subset])].set(
                     initial_positions
                 )
+            if thermodynamic_state.pressure is not None:
+                thermodynamic_state.volume = initial_volume
+                thermoydnamic_state.box_vectors = initial_box_vectors
+
             log.debug(
                 f"Move rejected. Energy change: {delta_energy:.3f} kT. Number of rejected moves: {self.n_proposed - self.n_accepted}."
             )

--- a/chiron/neighbors.py
+++ b/chiron/neighbors.py
@@ -369,6 +369,23 @@ class PairsBase(ABC):
         self._box_vectors = box_vectors
         self.space.box_vectors = box_vectors
 
+    def wrap(self, coordinates: jnp.array) -> jnp.array:
+        """
+        Wrap the coordinates of the system.
+
+        Parameters
+        ----------
+        coordinates: jnp.array
+            Coordinates of the system
+
+        Returns
+        -------
+        jnp.array
+            Wrapped coordinates of the system
+
+        """
+        return self.space.wrap(coordinates)
+
 
 class NeighborListNsqrd(PairsBase):
     """

--- a/chiron/potential.py
+++ b/chiron/potential.py
@@ -63,6 +63,72 @@ class NeuralNetworkPotential:
         return distance[interacting_mask], displacement_vectors[interacting_mask], pairs
 
 
+class IdealGasPotential(NeuralNetworkPotential):
+    def __init__(
+        self,
+        topology: Topology,
+    ):
+        """
+        Initialize the Ideal Gas potential.
+
+        Parameters
+        ----------
+        topology : Topology
+            The topology of the system
+
+        """
+
+        if not isinstance(topology, Topology):
+            if not isinstance(topology, property):
+                if topology is not None:
+                    raise TypeError(
+                        f"Topology must be a Topology object or None, type(topology) = {type(topology)}"
+                    )
+
+        self.topology = topology
+
+    def compute_energy(self, positions: jnp.array, nbr_list=None, debug_mode=False):
+        """
+        Compute the energy for an ideal gas, which is always 0.
+
+        Parameters
+        ----------
+        positions : jnp.array
+            The positions of the particles in the system
+        nbr_list : NeighborList, default=None
+            Instance of a neighbor list or pair list class to use.
+            If None, an unoptimized N^2 pairlist will be used without PBC conditions.
+        Returns
+        -------
+        potential_energy : float
+            The total potential energy of the system.
+
+        """
+        # Compute the pair distances and displacement vectors
+
+        return 0.0
+
+    def compute_force(self, positions: jnp.array, nbr_list=None) -> jnp.array:
+        """
+        Compute the  force for ideal gas particles, which is always 0.
+
+        Parameters
+        ----------
+        positions : jnp.array
+            The positions of the particles in the system
+        nbr_list : NeighborList, optional
+            Instance of the neighborlist class to use. By default, set to None, which will use an N^2 pairlist
+
+        Returns
+        -------
+        force : jnp.array
+            The forces on the particles in the system
+
+        """
+
+        return 0.0
+
+
 class LJPotential(NeuralNetworkPotential):
     def __init__(
         self,

--- a/chiron/states.py
+++ b/chiron/states.py
@@ -283,12 +283,15 @@ class ThermodynamicState:
         ) / unit.AVOGADRO_CONSTANT_NA
         log.debug(f"reduced potential: {reduced_potential}")
         if self.pressure is not None:
-            self.volume = (
-                sampler_state.box_vectors[0][0]
-                * sampler_state.box_vectors[1][1]
-                * sampler_state.box_vectors[2][2]
-            )
-            reduced_potential += self.pressure * self.volume
+            # in case volume is not set, calculate from the box vectors
+            if self.volume is None:
+                self.volume = (
+                    sampler_state.box_vectors[0][0]
+                    * sampler_state.box_vectors[1][1]
+                    * sampler_state.box_vectors[2][2]
+                )
+
+            reduced_potential += self.pressure * self.volume * unit.nanometer**3
 
         return self.beta * reduced_potential
 

--- a/chiron/states.py
+++ b/chiron/states.py
@@ -186,6 +186,7 @@ class ThermodynamicState:
             self.beta = None
 
         self.volume = volume
+
         self.pressure = pressure
 
         from .utils import get_nr_of_particles
@@ -271,9 +272,7 @@ class ThermodynamicState:
         and N(x) is the number of particles.
         """
         if self.beta is None:
-            self.beta = 1.0 / (
-                unit.BOLTZMANN_CONSTANT_kB * (self.temperature * unit.kelvin)
-            )
+            self.beta = 1.0 / (unit.BOLTZMANN_CONSTANT_kB * (self.temperature))
         log.debug(f"sample state: {sampler_state.x0}")
         reduced_potential = (
             unit.Quantity(
@@ -281,7 +280,7 @@ class ThermodynamicState:
                 unit.kilojoule_per_mole,
             )
         ) / unit.AVOGADRO_CONSTANT_NA
-        log.debug(f"reduced potential: {reduced_potential}")
+        log.debug(f"reduced potential energy: {reduced_potential}")
         if self.pressure is not None:
             # in case volume is not set, calculate from the box vectors
             if self.volume is None:
@@ -289,9 +288,10 @@ class ThermodynamicState:
                     sampler_state.box_vectors[0][0]
                     * sampler_state.box_vectors[1][1]
                     * sampler_state.box_vectors[2][2]
-                )
+                ) * unit.nanometer**3
 
-            reduced_potential += self.pressure * self.volume * unit.nanometer**3
+            reduced_potential += self.pressure * self.volume
+            log.debug(f"reduced potential energy + pV: {reduced_potential}")
 
         return self.beta * reduced_potential
 

--- a/chiron/states.py
+++ b/chiron/states.py
@@ -92,6 +92,13 @@ class SamplerState:
         else:
             self._x0 = unit.Quantity(x0, self._distance_unit)
 
+    @box_vectors.setter
+    def box_vectors(self, box_vectors: Union[jnp.array, unit.Quantity]) -> None:
+        if isinstance(box_vectors, unit.Quantity):
+            self._box_vectors = box_vectors
+        else:
+            self._box_vectors = unit.Quantity(box_vectors, self._distance_unit)
+
     @property
     def distance_unit(self) -> unit.Unit:
         return self._distance_unit

--- a/chiron/states.py
+++ b/chiron/states.py
@@ -273,15 +273,13 @@ class ThermodynamicState:
         """
         if self.beta is None:
             self.beta = 1.0 / (unit.BOLTZMANN_CONSTANT_kB * (self.temperature))
-        # log.debug(f"beta: {self.beta}")
-        # log.debug(f"sample state: {sampler_state.x0}")
+
         reduced_potential = (
             unit.Quantity(
                 self.potential.compute_energy(sampler_state.x0, nbr_list),
                 unit.kilojoule_per_mole,
             )
         ) / unit.AVOGADRO_CONSTANT_NA
-        log.debug(f"reduced potential energy: {reduced_potential}")
         if self.pressure is not None:
             # in case volume is not set, calculate from the box vectors
             if self.volume is None:
@@ -291,8 +289,8 @@ class ThermodynamicState:
                     * sampler_state.box_vectors[2][2]
                 ) * unit.nanometer**3
             reduced_potential += self.pressure * self.volume
-            log.debug(f"pV: {self.pressure * self.volume}")
-            log.debug(f"reduced potential energy + pV: {reduced_potential}")
+
+        log.debug(f"reduced potential energy: {reduced_potential}")
 
         return self.beta * reduced_potential
 

--- a/chiron/states.py
+++ b/chiron/states.py
@@ -273,7 +273,8 @@ class ThermodynamicState:
         """
         if self.beta is None:
             self.beta = 1.0 / (unit.BOLTZMANN_CONSTANT_kB * (self.temperature))
-        log.debug(f"sample state: {sampler_state.x0}")
+        # log.debug(f"beta: {self.beta}")
+        # log.debug(f"sample state: {sampler_state.x0}")
         reduced_potential = (
             unit.Quantity(
                 self.potential.compute_energy(sampler_state.x0, nbr_list),
@@ -289,8 +290,8 @@ class ThermodynamicState:
                     * sampler_state.box_vectors[1][1]
                     * sampler_state.box_vectors[2][2]
                 ) * unit.nanometer**3
-
             reduced_potential += self.pressure * self.volume
+            log.debug(f"pV: {self.pressure * self.volume}")
             log.debug(f"reduced potential energy + pV: {reduced_potential}")
 
         return self.beta * reduced_potential

--- a/chiron/states.py
+++ b/chiron/states.py
@@ -283,6 +283,11 @@ class ThermodynamicState:
         ) / unit.AVOGADRO_CONSTANT_NA
         log.debug(f"reduced potential: {reduced_potential}")
         if self.pressure is not None:
+            self.volume = (
+                sampler_state.box_vectors[0][0]
+                * sampler_state.box_vectors[1][1]
+                * sampler_state.box_vectors[2][2]
+            )
             reduced_potential += self.pressure * self.volume
 
         return self.beta * reduced_potential

--- a/chiron/tests/test_convergence_tests.py
+++ b/chiron/tests/test_convergence_tests.py
@@ -44,7 +44,9 @@ def test_convergence_of_MC_estimator(prep_temp_dir):
     from chiron.states import ThermodynamicState, SamplerState
 
     thermodynamic_state = ThermodynamicState(
-        harmonic_potential, temperature=300, volume=30 * (unit.angstrom**3)
+        harmonic_potential,
+        temperature=300 * unit.kelvin,
+        volume=30 * (unit.angstrom**3),
     )
     sampler_state = SamplerState(ho.positions)
 
@@ -52,7 +54,9 @@ def test_convergence_of_MC_estimator(prep_temp_dir):
 
     id = uuid.uuid4()
 
-    simulation_reporter = SimulationReporter(f"{prep_temp_dir}/test_{id}.h5")
+    simulation_reporter = SimulationReporter(
+        f"{prep_temp_dir}/test_{id}.h5", ho.topology
+    )
 
     # Initalize the move set (here only LangevinDynamicsMove)
     from chiron.mcmc import MetropolisDisplacementMove, MoveSet, MCMCSampler
@@ -113,7 +117,7 @@ def test_convergence_of_MC_estimator(prep_temp_dir):
     )
 
 
-@pytest.mark.skip(reason="Tests takes too long")
+# @pytest.mark.skip(reason="Tests takes too long")
 @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test takes too long.")
 def test_langevin_dynamics_with_LJ_fluid(prep_temp_dir):
     from chiron.integrators import LangevinIntegrator
@@ -156,7 +160,7 @@ def test_langevin_dynamics_with_LJ_fluid(prep_temp_dir):
     from chiron.reporters import SimulationReporter
 
     id = uuid.uuid4()
-    reporter = SimulationReporter(f"{prep_temp_dir}/test_{id}.h5")
+    reporter = SimulationReporter(f"{prep_temp_dir}/test_{id}.h5", lj_fluid.topology)
 
     integrator = LangevinIntegrator(reporter=reporter, save_frequency=100)
     integrator.run(

--- a/chiron/tests/test_mcmc.py
+++ b/chiron/tests/test_mcmc.py
@@ -281,11 +281,11 @@ def test_mc_barostat_setting():
 
     barostat_move = MCBarostatMove(
         seed=1234,
-        volume_max_scale=0.01,
-        nr_of_moves=2,
+        volume_max_scale=0.1,
+        nr_of_moves=10,
     )
 
-    assert barostat_move.volume_max_scale == 0.01
+    assert barostat_move.volume_max_scale == 0.1
 
     from chiron.potential import LJPotential
     from openmm import unit
@@ -351,27 +351,27 @@ def test_mc_barostat_setting():
 
     barostat_move.run(sampler_state, thermodynamic_state, nbr_list, True)
 
-    assert barostat_move.statistics["n_accepted"] == 1
-    assert barostat_move.statistics["n_proposed"] == 2
+    assert barostat_move.statistics["n_accepted"] == 7
+    assert barostat_move.statistics["n_proposed"] == 10
 
     assert jnp.all(
         sampler_state.x0
         == jnp.array(
             [
                 [0.0, 0.0, 0.0],
-                [0.99709356, 0.0, 0.0],
-                [0.0, 0.99709356, 0.0],
-                [0.0, 0.0, 0.99709356],
-                [0.99709356, 0.99709356, 0.0],
-                [0.99709356, 0.0, 0.99709356],
-                [0.0, 0.99709356, 0.99709356],
-                [0.99709356, 0.99709356, 0.99709356],
+                [0.9871503, 0.0, 0.0],
+                [0.0, 0.9871503, 0.0],
+                [0.0, 0.0, 0.9871503],
+                [0.9871503, 0.9871503, 0.0],
+                [0.9871503, 0.0, 0.9871503],
+                [0.0, 0.9871503, 0.9871503],
+                [0.9871503, 0.9871503, 0.9871503],
             ]
         )
     )
     assert jnp.all(
         sampler_state.box_vectors
-        == jnp.array([[9.987228, 0.0, 0.0], [0.0, 9.987228, 0.0], [0.0, 0.0, 9.987228]])
+        == jnp.array([[9.16151, 0.0, 0.0], [0.0, 9.16151, 0.0], [0.0, 0.0, 9.16151]])
     )
 
 

--- a/chiron/tests/test_mcmc.py
+++ b/chiron/tests/test_mcmc.py
@@ -282,7 +282,7 @@ def test_mc_barostat_setting():
     barostat_move = MCBarostatMove(
         seed=1234,
         volume_max_scale=0.01,
-        nr_of_moves=10,
+        nr_of_moves=2,
     )
 
     assert barostat_move.volume_max_scale == 0.01
@@ -350,6 +350,29 @@ def test_mc_barostat_setting():
     )
 
     barostat_move.run(sampler_state, thermodynamic_state, nbr_list, True)
+
+    assert barostat_move.statistics["n_accepted"] == 1
+    assert barostat_move.statistics["n_proposed"] == 2
+
+    assert jnp.all(
+        sampler_state.x0
+        == jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.99709356, 0.0, 0.0],
+                [0.0, 0.99709356, 0.0],
+                [0.0, 0.0, 0.99709356],
+                [0.99709356, 0.99709356, 0.0],
+                [0.99709356, 0.0, 0.99709356],
+                [0.0, 0.99709356, 0.99709356],
+                [0.99709356, 0.99709356, 0.99709356],
+            ]
+        )
+    )
+    assert jnp.all(
+        sampler_state.box_vectors
+        == jnp.array([[9.987228, 0.0, 0.0], [0.0, 9.987228, 0.0], [0.0, 0.0, 9.987228]])
+    )
 
 
 def test_sample_from_joint_distribution_of_two_HO_with_local_moves_and_MC_updates():

--- a/chiron/tests/test_mcmc.py
+++ b/chiron/tests/test_mcmc.py
@@ -354,9 +354,9 @@ def test_mc_barostat_setting():
     assert barostat_move.statistics["n_accepted"] == 7
     assert barostat_move.statistics["n_proposed"] == 10
 
-    assert jnp.all(
-        sampler_state.x0
-        == jnp.array(
+    assert jnp.allclose(
+        sampler_state.x0,
+        jnp.array(
             [
                 [0.0, 0.0, 0.0],
                 [0.9871503, 0.0, 0.0],
@@ -367,11 +367,11 @@ def test_mc_barostat_setting():
                 [0.0, 0.9871503, 0.9871503],
                 [0.9871503, 0.9871503, 0.9871503],
             ]
-        )
+        ),
     )
-    assert jnp.all(
-        sampler_state.box_vectors
-        == jnp.array([[9.16151, 0.0, 0.0], [0.0, 9.16151, 0.0], [0.0, 0.0, 9.16151]])
+    assert jnp.allclose(
+        sampler_state.box_vectors,
+        jnp.array([[9.16151, 0.0, 0.0], [0.0, 9.16151, 0.0], [0.0, 0.0, 9.16151]]),
     )
 
 

--- a/chiron/tests/test_testsystems.py
+++ b/chiron/tests/test_testsystems.py
@@ -1,3 +1,13 @@
+import pytest
+
+
+@pytest.fixture(scope="session")
+def prep_temp_dir(tmpdir_factory):
+    """Create a temporary directory for the test."""
+    tmpdir = tmpdir_factory.mktemp("test_testsystems")
+    return tmpdir
+
+
 def compute_openmm_reference_energy(testsystem, positions):
     from openmm import unit
     from openmm.app import Simulation
@@ -203,3 +213,115 @@ def test_LJ_fluid():
         assert jnp.isclose(
             e_chiron_energy, e_openmm_energy.value_in_unit_system(unit.md_unit_system)
         ), "Chiron LJ fluid energy does not match openmm"
+
+
+def test_ideal_gas(prep_temp_dir):
+    from openmmtools.testsystems import IdealGas
+    from openmm import unit
+
+    # Use the LennardJonesFluid example from openmmtools to initialize particle positions and topology
+    # For this example, the topology provides the masses for the particles
+    # The default LennardJonesFluid example considers the system to be Argon with 39.9 amu
+    n_particles = 216
+    temperature = 298 * unit.kelvin
+    pressure = 1 * unit.atmosphere
+    mass = unit.Quantity(39.9, unit.gram / unit.mole)
+
+    ideal_gas = IdealGas(
+        nparticles=n_particles, temperature=temperature, pressure=pressure
+    )
+
+    from chiron.potential import IdealGasPotential
+    import jax.numpy as jnp
+
+    #
+    cutoff = 0.0 * unit.nanometer
+    ideal_gas_potential = IdealGasPotential(ideal_gas.topology)
+
+    from chiron.states import SamplerState, ThermodynamicState
+
+    # define the thermodynamic state
+    thermodynamic_state = ThermodynamicState(
+        potential=ideal_gas_potential,
+        temperature=temperature,
+        pressure=pressure,
+    )
+
+    # define the sampler state
+    sampler_state = SamplerState(
+        x0=ideal_gas.positions,
+        box_vectors=ideal_gas.system.getDefaultPeriodicBoxVectors(),
+    )
+
+    from chiron.neighbors import PairList, OrthogonalPeriodicSpace
+
+    # define the pair list for an orthogonal periodic space
+    # since particles are non-interacting, this will not really do much
+    # but will appropriately wrap particles in space
+    nbr_list = PairList(OrthogonalPeriodicSpace(), cutoff=cutoff)
+    nbr_list.build_from_state(sampler_state)
+
+    from chiron.reporters import SimulationReporter
+
+    # initialize a reporter to save the simulation data
+    filename = f"{prep_temp_dir}/test_ideal_gas_vol.h5"
+
+    reporter1 = SimulationReporter(filename, ideal_gas.topology, 100)
+
+    from chiron.mcmc import (
+        MetropolisDisplacementMove,
+        MoveSet,
+        MCMCSampler,
+        MCBarostatMove,
+    )
+
+    mc_disp_move = MetropolisDisplacementMove(
+        seed=1234,
+        displacement_sigma=0.1 * unit.nanometer,
+        nr_of_moves=10,
+    )
+
+    mc_barostat_move = MCBarostatMove(
+        seed=1234,
+        volume_max_scale=0.2,
+        nr_of_moves=100,
+        adjust_box_scaling=True,
+        adjust_frequency=50,
+        simulation_reporter=reporter1,
+    )
+    move_set = MoveSet(
+        [
+            ("MetropolisDisplacementMove", mc_disp_move),
+            ("MCBarostatMove", mc_barostat_move),
+        ]
+    )
+
+    sampler = MCMCSampler(move_set, sampler_state, thermodynamic_state)
+    sampler.run(n_iterations=30, nbr_list=nbr_list)  # how many times to repeat
+
+    import h5py
+
+    with h5py.File(filename, "r") as f:
+        volume = f["volume"][:]
+        steps = f["step"][:]
+
+    # get expectations
+    ideal_volume = ideal_gas.get_volume_expectation(thermodynamic_state)
+    ideal_volume_std = ideal_gas.get_volume_standard_deviation(thermodynamic_state)
+
+    volume_mean = jnp.mean(jnp.array(volume)) * unit.nanometer**3
+    volume_std = jnp.std(jnp.array(volume)) * unit.nanometer**3
+
+    ideal_density = mass * n_particles / unit.AVOGADRO_CONSTANT_NA / ideal_volume
+    measured_density = mass * n_particles / unit.AVOGADRO_CONSTANT_NA / volume_mean
+
+    assert jnp.isclose(
+        ideal_density.value_in_unit(unit.kilogram / unit.meter**3),
+        measured_density.value_in_unit(unit.kilogram / unit.meter**3),
+        atol=1e-1,
+    )
+    # see if within 5% of ideal volume
+    assert abs(ideal_volume - volume_mean) / ideal_volume < 0.05
+
+    # see if within 10% of the ideal standard deviation of the volume
+    assert abs(ideal_volume_std - volume_std) / ideal_volume_std < 0.1


### PR DESCRIPTION
## Description
This PR implements a simple isotropic MC barostat. This modifies the metroplizedmove base class such that it can handle the barostat move.  This has included changing the `_propose_positions` function to take/return box_vectors.  Additional changes include storing initial/final box volume if pressure is defined. 

Note, this will dilate all atoms in the system; for molecular systems we'll need to implement functionality to handle inference of molecules and scaling based on molecule COM. 

Edit (24/01/11): After quick discussion of this in the meeting today, I think it is evident we will need to do a major refactor of how we implement the MC move classes after we get these initial ones committed, as the code is definitely starting to get a bit messy.  We shouldn't get bogged down with that in this PR, so that we can have these routines to use for other development.  I think the overall API used by the MCMCSampler class won't need to change (basically will still just calling `run` regardless of the rest of the code structure) so refactoring should basically be plug and play and not necessarily break things. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] MC barostat example
  - [x] MC barostat tests 
  - [x] Commit ideal gas test system.

## Status
- [x] Ready to go