### PR TITLE
Adding offline mbar analysis

### DIFF
--- a/chiron/mcmc.py
+++ b/chiron/mcmc.py
@@ -71,6 +71,7 @@ class LangevinDynamicsMove(MCMCMove):
         simulation_reporter: Optional[SimulationReporter] = None,
         nr_of_steps=1_000,
         seed: int = 1234,
+        save_traj_in_memory: bool = False,
     ):
         """
         Initialize the LangevinDynamicsMove with a molecular system.
@@ -88,13 +89,15 @@ class LangevinDynamicsMove(MCMCMove):
         self.stepsize = stepsize
         self.collision_rate = collision_rate
         self.simulation_reporter = simulation_reporter
-
+        self.save_traj_in_memory = save_traj_in_memory
+        self.traj = []
         from chiron.integrators import LangevinIntegrator
 
         self.integrator = LangevinIntegrator(
             stepsize=self.stepsize,
             collision_rate=self.collision_rate,
             reporter=self.simulation_reporter,
+            save_traj_in_memory=save_traj_in_memory,
         )
 
     def run(
@@ -122,6 +125,9 @@ class LangevinDynamicsMove(MCMCMove):
             n_steps=self.nr_of_moves,
             key=self.key,
         )
+        if self.save_traj_in_memory:
+            self.traj.append(self.integrator.traj)
+            self.integrator.traj = []
 
 
 class MCMove(MCMCMove):

--- a/chiron/multistate.py
+++ b/chiron/multistate.py
@@ -611,10 +611,6 @@ class MultiStateSampler(object):
             self._energy_thermodynamic_states_for_each_iteration_in_run[
                 :, :, self._iteration
             ] = self._energy_thermodynamic_states
-            log.info(
-                self._energy_thermodynamic_states_for_each_iteration_in_run[:, :, 1]
-            )
-            log.info(self._energy_thermodynamic_states)
             # Write iteration to storage file
             # TODO
             # self._report_iteration()

--- a/chiron/multistate.py
+++ b/chiron/multistate.py
@@ -71,6 +71,7 @@ class MultiStateSampler(object):
         self._metadata = None
         self._online_analysis_interval = online_analysis_interval
         self._timing_data = dict()
+        self.free_energy_estimator = None
 
         # Handling default propagator.
         if mcmc_moves is None:
@@ -240,6 +241,7 @@ class MultiStateSampler(object):
         """
         # TODO: initialize reporter here
         # TODO: consider unsampled thermodynamic states for reweighting schemes
+        self.free_energy_estimator = "mbar"
 
         # Ensure the number of thermodynamic states matches the number of sampler states
         if len(thermodynamic_states) != len(sampler_states):
@@ -999,6 +1001,7 @@ class MultiStateSampler(object):
         from jax.scipy.special import logsumexp
 
         gamma = 1.0 / self._iteration + 1
+        gamma = 1.0
 
         self._last_mbar_f_k = np.zeros([self.n_states], np.float64)
 

--- a/chiron/reporters.py
+++ b/chiron/reporters.py
@@ -21,8 +21,6 @@ class SimulationReporter:
             Number of data points to buffer before writing to disk (default is 1).
 
         """
-        import mdtraj as md
-
         self.filename = filename
         self.buffer_size = buffer_size
         self.topology = topology
@@ -52,7 +50,7 @@ class SimulationReporter:
             if len(self.buffer[key]) >= self.buffer_size:
                 self._write_to_disk(key)
 
-    def _write_to_disk(self, key):
+    def _write_to_disk(self, key:str):
         """
         Write buffered data of a given key to the HDF5 file.
 

--- a/chiron/states.py
+++ b/chiron/states.py
@@ -274,14 +274,14 @@ class ThermodynamicState:
             self.beta = 1.0 / (
                 unit.BOLTZMANN_CONSTANT_kB * (self.temperature * unit.kelvin)
             )
-        log.debug(f"sample state: {sampler_state.x0}")
+        # log.debug(f"sample state: {sampler_state.x0}")
         reduced_potential = (
             unit.Quantity(
                 self.potential.compute_energy(sampler_state.x0, nbr_list),
                 unit.kilojoule_per_mole,
             )
         ) / unit.AVOGADRO_CONSTANT_NA
-        log.debug(f"reduced potential: {reduced_potential}")
+        # log.debug(f"reduced potential: {reduced_potential}")
         if self.pressure is not None:
             reduced_potential += self.pressure * self.volume
 

--- a/chiron/states.py
+++ b/chiron/states.py
@@ -217,32 +217,6 @@ class ThermodynamicState:
         if self.temperature and self.pressure and self.nr_of_particles:
             log.info("NpT ensemble is simulated.")
 
-    def is_state_compatible(self, thermodynamic_state):
-        """Check compatibility between ThermodynamicStates.
-
-        Parameters
-        ----------
-        thermodynamic_state : ThermodynamicState
-            The thermodynamic state to test.
-
-        Returns
-        -------
-        is_compatible : bool
-            True if the states are compatible, False otherwise.
-
-        Examples
-        --------
-        States in the same ensemble (NVT or NPT) are compatible.
-        States in different ensembles are not compatible.
-        States that store different systems (that differ by more than
-        barostat and thermostat pressure and temperature) are also not
-        compatible.
-        """
-
-        # Check that the states are in the same ensemble.
-        # TODO: implement this
-        pass
-
     def get_reduced_potential(
         self, sampler_state: SamplerState, nbr_list=None
     ) -> float:
@@ -294,7 +268,7 @@ class ThermodynamicState:
 
 def calculate_reduced_potential_at_states(
     sampler_state: SamplerState,
-    themrodynamic_states: List[ThermodynamicState],
+    thermodynamic_states: List[ThermodynamicState],
     nbr_list=None,
 ):
     """
@@ -313,7 +287,10 @@ def calculate_reduced_potential_at_states(
         The reduced potential of the system for each thermodynamic state.
 
     """
-    reduced_potentials = []
-    for state in themrodynamic_states:
-        reduced_potentials.append(state.get_reduced_potential(sampler_state))
+    import numpy as np
+
+    reduced_potentials = np.zeros(len(thermodynamic_states))
+    for state_idx, state in enumerate(thermodynamic_states):
+        reduced_potentials[state_idx] = state.get_reduced_potential(sampler_state)
+    log.debug(f"reduced potentials per sampler sate: {reduced_potentials}")
     return reduced_potentials

--- a/chiron/tests/test_multistate.py
+++ b/chiron/tests/test_multistate.py
@@ -76,7 +76,7 @@ def ho_multistate_sampler_multiple_ks() -> MultiStateSampler:
     Create a multi-state sampler for a harmonic oscillator system with different spring constants.
     Returns
     -------
-    MultiStateSampler 
+    MultiStateSampler
         The multi-state sampler object.
     """
     from openmm import unit
@@ -131,11 +131,11 @@ def test_multistate_class(ho_multistate_sampler_multiple_minima: MultiStateSampl
 
     Parameters:
     -------
-    ho_multistate_sampler_multiple_minima: MultiStateSampler 
+    ho_multistate_sampler_multiple_minima: MultiStateSampler
         An instance of the MultiStateSampler class.
     Raises:
     -------
-    AssertionError: 
+    AssertionError:
         If any of the assertions fail.
 
     """
@@ -212,6 +212,6 @@ def test_multistate_run(ho_multistate_sampler_multiple_ks: MultiStateSampler):
     print(ho_sampler.delta_f_ij_analytical)
     print(ho_sampler._last_mbar_f_k_offline)
 
-    assert np.isclose(
-        ho_sampler.delta_f_ij_analytical[0], ho_sampler._last_mbar_f_k_offline
+    assert np.allclose(
+        ho_sampler.delta_f_ij_analytical[0], ho_sampler._last_mbar_f_k_offline, atol=0.1
     )

--- a/chiron/tests/test_multistate.py
+++ b/chiron/tests/test_multistate.py
@@ -2,46 +2,10 @@ from chiron.multistate import MultiStateSampler
 import pytest
 
 
-@pytest.fixture
-def ho_multistate_sampler() -> MultiStateSampler:
-    """
-    Create a multi-state sampler for a harmonic oscillator system.
-
-    Returns:
-        MultiStateSampler: The multi-state sampler object.
-    """
-    import math
+def setup_sampler():
     from openmm import unit
     from chiron.mcmc import LangevinDynamicsMove
-    from chiron.states import ThermodynamicState, SamplerState
-    from openmmtools.testsystems import HarmonicOscillator
-    from chiron.potential import HarmonicOscillatorPotential
     from chiron.neighbors import NeighborListNsqrd, OrthogonalPeriodicSpace
-
-    ho = HarmonicOscillator()
-    n_replicas = 3
-    T_min = 298.0 * unit.kelvin  # Minimum temperature.
-    T_max = 600.0 * unit.kelvin  # Maximum temperature.
-    temperatures = [
-        T_min
-        + (T_max - T_min)
-        * (math.exp(float(i) / float(n_replicas - 1)) - 1.0)
-        / (math.e - 1.0)
-        for i in range(n_replicas)
-    ]
-    import jax.numpy as jnp
-
-    x0s = [
-        unit.Quantity(jnp.array([[x0, 0.0, 0.0]]), unit.angstrom)
-        for x0 in jnp.linspace(0.0, 1.0, n_replicas)
-    ]
-    thermodynamic_states = [
-        ThermodynamicState(
-            HarmonicOscillatorPotential(ho.topology, x0=x0), temperature=T
-        )
-        for T, x0 in zip(temperatures, x0s)
-    ]
-    sampler_state = [SamplerState(ho.positions) for _ in temperatures]
 
     # Initialize simulation object with options. Run with a langevin integrator.
     # initialize the LennardJones potential in chiron
@@ -56,31 +20,115 @@ def ho_multistate_sampler() -> MultiStateSampler:
 
     move = LangevinDynamicsMove(stepsize=2.0 * unit.femtoseconds, nr_of_steps=50)
 
-    from openmmtools.multistate import MultiStateReporter
+    multistate_sampler = MultiStateSampler(mcmc_moves=move)
+    return nbr_list, multistate_sampler
 
-    reporter = MultiStateReporter("test.nc")
 
-    multistate_sampler = MultiStateSampler(mcmc_moves=move, number_of_iterations=2)
+@pytest.fixture
+def ho_multistate_sampler_multiple_minima() -> MultiStateSampler:
+    """
+    Create a multi-state sampler for a harmonic oscillator system.
+
+    Returns:
+        MultiStateSampler: The multi-state sampler object.
+    """
+    from chiron.states import ThermodynamicState, SamplerState
+    from chiron.potential import HarmonicOscillatorPotential
+    import jax.numpy as jnp
+    from openmm import unit
+
+    n_replicas = 3
+    T = 300.0 * unit.kelvin  # Minimum temperature.
+    x0s = [
+        unit.Quantity(jnp.array([[x0, 0.0, 0.0]]), unit.angstrom)
+        for x0 in jnp.linspace(0.0, 1.0, n_replicas)
+    ]
+
+    from openmmtools.testsystems import HarmonicOscillator
+
+    ho = HarmonicOscillator()
+
+    thermodynamic_states = [
+        ThermodynamicState(
+            HarmonicOscillatorPotential(ho.topology, x0=x0), temperature=T
+        )
+        for x0 in x0s
+    ]
+    sampler_state = [SamplerState(ho.positions) for _ in x0s]
+    nbr_list, multistate_sampler = setup_sampler()
     multistate_sampler.create(
         thermodynamic_states=thermodynamic_states,
         sampler_states=sampler_state,
         nbr_list=nbr_list,
-        reporter=reporter,
     )
 
     return multistate_sampler
 
 
-def test_multistate_class(ho_multistate_sampler):
+@pytest.fixture
+def ho_multistate_sampler_multiple_ks() -> MultiStateSampler:
+    """
+    Create a multi-state sampler for a harmonic oscillator system.
+
+    Returns:
+        MultiStateSampler: The multi-state sampler object.
+    """
+    from openmm import unit
+    from chiron.states import ThermodynamicState, SamplerState
+    from openmmtools.testsystems import HarmonicOscillator
+    from chiron.potential import HarmonicOscillatorPotential
+
+    ho = HarmonicOscillator()
+    n_states = 4
+
+    T = 300.0 * unit.kelvin  # Minimum temperature.
+    kT = unit.BOLTZMANN_CONSTANT_kB * T * unit.AVOGADRO_CONSTANT_NA
+    sigmas = [
+        unit.Quantity(2.0 + 0.2 * state_index, unit.angstrom)
+        for state_index in range(n_states)
+    ]
+    Ks = [kT / sigma**2 for sigma in sigmas]
+
+    thermodynamic_states = [
+        ThermodynamicState(HarmonicOscillatorPotential(ho.topology, k=k), temperature=T)
+        for k in Ks
+    ]
+    from loguru import logger as log
+
+    log.info(f"Initialize harmonic oscillator with {n_states} states and ks {Ks}")
+
+    sampler_state = [SamplerState(ho.positions) for _ in sigmas]
+    import numpy as np
+
+    f_i = np.array(
+        [
+            -np.log(2 * np.pi * (sigma / unit.angstroms) ** 2) * (3.0 / 2.0)
+            for sigma in sigmas
+        ]
+    )
+
+    nbr_list, multistate_sampler = setup_sampler()
+
+    multistate_sampler.create(
+        thermodynamic_states=thermodynamic_states,
+        sampler_states=sampler_state,
+        nbr_list=nbr_list,
+    )
+    multistate_sampler.analytical_f_i = f_i
+    multistate_sampler.delta_f_ij_analytical = f_i - f_i[:, np.newaxis]
+    return multistate_sampler
+
+
+def test_multistate_class(ho_multistate_sampler_multiple_minima: MultiStateSampler):
     # test the multistate_sampler object
-    assert ho_multistate_sampler.number_of_iterations == 2
-    assert ho_multistate_sampler.n_replicas == 3
-    assert ho_multistate_sampler.n_states == 3
-    assert ho_multistate_sampler._energy_thermodynamic_states.shape == (3, 3)
-    assert ho_multistate_sampler._n_proposed_matrix.shape == (3, 3)
+    assert ho_multistate_sampler_multiple_minima._iteration == 0
+    assert ho_multistate_sampler_multiple_minima.n_replicas == 3
+    assert ho_multistate_sampler_multiple_minima.n_states == 3
+    assert ho_multistate_sampler_multiple_minima._energy_thermodynamic_states.shape == (3, 3)
+    assert ho_multistate_sampler_multiple_minima._n_proposed_matrix.shape == (3, 3)
 
 
-def test_multistate_minimize(ho_multistate_sampler):
+def test_multistate_minimize(ho_multistate_sampler_multiple_minima: MultiStateSampler):
     """
     Test function for the `minimize` method of the `ho_multistate_sampler` object.
     It checks if the sampler states are correctly minimized.
@@ -92,115 +140,25 @@ def test_multistate_minimize(ho_multistate_sampler):
 
     import numpy as np
 
-    ho_multistate_sampler.minimize()
+    ho_multistate_sampler_multiple_minima.minimize()
 
     assert np.allclose(
-        ho_multistate_sampler.sampler_states[0].x0, np.array([[0.0, 0.0, 0.0]])
+        ho_multistate_sampler_multiple_minima.sampler_states[0].x0, np.array([[0.0, 0.0, 0.0]])
     )
     assert np.allclose(
-        ho_multistate_sampler.sampler_states[1].x0,
+        ho_multistate_sampler_multiple_minima.sampler_states[1].x0,
         np.array([[0.05, 0.0, 0.0]]),
         atol=1e-2,
     )
     assert np.allclose(
-        ho_multistate_sampler.sampler_states[2].x0,
+        ho_multistate_sampler_multiple_minima.sampler_states[2].x0,
         np.array([[0.1, 0.0, 0.0]]),
         atol=1e-2,
     )
 
 
-def test_multistate_equilibration(ho_multistate_sampler):
-    import numpy as np
-
-    ho_multistate_sampler.equilibrate(10)
-
-    assert np.allclose(
-        ho_multistate_sampler._replica_thermodynamic_states, np.array([0, 1, 2])
-    )
-    assert np.allclose(
-        ho_multistate_sampler._energy_thermodynamic_states,
-        np.array(
-            [
-                [4.81132936, 3.84872651, 3.10585403],
-                [6.54490519, 5.0176239, 3.85019779],
-                [9.48260307, 7.07196712, 5.21255827],
-            ]
-        ),
-    )
-
-
-@pytest.fixture
-def ho_multistate_sampler_single_sampler_state() -> MultiStateSampler:
-    """
-    Create a multi-state sampler for a harmonic oscillator system.
-
-    Returns:
-        MultiStateSampler: The multi-state sampler object.
-    """
-    from openmm import unit
-    from chiron.mcmc import LangevinDynamicsMove
-    from chiron.states import ThermodynamicState, SamplerState
-    from openmmtools.testsystems import HarmonicOscillator
-    from chiron.potential import HarmonicOscillatorPotential
-    from chiron.neighbors import NeighborListNsqrd, OrthogonalPeriodicSpace
-
-    ho = HarmonicOscillator()
-    n_states = 4
-
-    T = 300.0 * unit.kelvin  # Minimum temperature.
-    kT = unit.BOLTZMANN_CONSTANT_kB * T * unit.AVOGADRO_CONSTANT_NA
-    sigmas = [
-        unit.Quantity(1.0 + 0.2 * state_index, unit.angstrom)
-        for state_index in range(n_states)
-    ]
-    Ks = [kT / sigma**2 for sigma in sigmas]
-    thermodynamic_states = [
-        ThermodynamicState(HarmonicOscillatorPotential(ho.topology, k=k), temperature=T)
-        for k in Ks
-    ]
-    sampler_state = [SamplerState(ho.positions) for _ in sigmas]
-    import numpy as np
-
-    f_i = np.array(
-        [
-            -np.log(2 * np.pi * (sigma / unit.angstroms) ** 2) * (3.0 / 2.0)
-            for sigma in sigmas
-        ]
-    )
-
-    # Initialize simulation object with options. Run with a langevin integrator.
-    # initialize the LennardJones potential in chiron
-    #
-    sigma = 0.34 * unit.nanometer
-    cutoff = 3.0 * sigma
-    skin = 0.5 * unit.nanometer
-
-    nbr_list = NeighborListNsqrd(
-        OrthogonalPeriodicSpace(), cutoff=cutoff, skin=skin, n_max_neighbors=10
-    )
-
-    move = LangevinDynamicsMove(stepsize=1.0 * unit.femtoseconds, nr_of_steps=100)
-
-    from openmmtools.multistate import MultiStateReporter
-
-    reporter = MultiStateReporter("test.nc")
-
-    multistate_sampler = MultiStateSampler(
-        mcmc_moves=move,
-    )
-    multistate_sampler.create(
-        thermodynamic_states=thermodynamic_states,
-        sampler_states=sampler_state,
-        nbr_list=nbr_list,
-        reporter=reporter,
-    )
-    multistate_sampler.analytical_f_i = f_i
-    multistate_sampler.delta_f_ij_analytical = f_i - f_i[:, np.newaxis]
-    return multistate_sampler
-
-
-def test_multistate_run(ho_multistate_sampler_single_sampler_state):
-    ho_sampler = ho_multistate_sampler_single_sampler_state
+def test_multistate_run(ho_multistate_sampler_multiple_ks: MultiStateSampler):
+    ho_sampler = ho_multistate_sampler_multiple_ks
     import numpy as np
 
     n_iteratinos = 100

--- a/chiron/tests/test_multistate.py
+++ b/chiron/tests/test_multistate.py
@@ -146,18 +146,16 @@ def ho_multistate_sampler_single_sampler_state() -> MultiStateSampler:
 
     ho = HarmonicOscillator()
     n_states = 4
-    
+
     T = 300.0 * unit.kelvin  # Minimum temperature.
     kT = unit.BOLTZMANN_CONSTANT_kB * T * unit.AVOGADRO_CONSTANT_NA
     sigmas = [
         unit.Quantity(1.0 + 0.2 * state_index, unit.angstrom)
         for state_index in range(n_states)
     ]
-    Ks = [kT / sigma ** 2 for sigma in sigmas]
+    Ks = [kT / sigma**2 for sigma in sigmas]
     thermodynamic_states = [
-        ThermodynamicState(
-            HarmonicOscillatorPotential(ho.topology, k=k), temperature=T
-        )
+        ThermodynamicState(HarmonicOscillatorPotential(ho.topology, k=k), temperature=T)
         for k in Ks
     ]
     sampler_state = [SamplerState(ho.positions) for _ in sigmas]
@@ -187,7 +185,9 @@ def ho_multistate_sampler_single_sampler_state() -> MultiStateSampler:
 
     reporter = MultiStateReporter("test.nc")
 
-    multistate_sampler = MultiStateSampler(mcmc_moves=move, number_of_iterations=10)
+    multistate_sampler = MultiStateSampler(
+        mcmc_moves=move,
+    )
     multistate_sampler.create(
         thermodynamic_states=thermodynamic_states,
         sampler_states=sampler_state,
@@ -203,8 +203,17 @@ def test_multistate_run(ho_multistate_sampler_single_sampler_state):
     ho_sampler = ho_multistate_sampler_single_sampler_state
     import numpy as np
 
-    ho_sampler.equilibrate(10)
-    ho_sampler.run(200)
+    n_iteratinos = 100
+    ho_sampler.run(n_iteratinos)
+
+    # check that we have the correct number of iterations, replicas and states
+    assert ho_sampler.iteration == n_iteratinos
+    assert ho_sampler._iteration == n_iteratinos
+    assert ho_sampler.n_replicas == 4
+    assert ho_sampler.n_states == 4
+
+    # check that the free energies are correct
     print(ho_sampler.analytical_f_i)
     print(ho_sampler.delta_f_ij_analytical)
+    print(ho_sampler._last_mbar_f_k_offline)
     a = 7

--- a/chiron/tests/test_states.py
+++ b/chiron/tests/test_states.py
@@ -124,11 +124,12 @@ def test_sampler_state_inputs():
         x0=unit.Quantity(jnp.array([[1, 2, 3]]), unit.nanometers),
         box_vectors=openmm_box,
     )
-    assert jnp.all(
+    assert jnp.allclose(
         state.box_vectors
         == jnp.array(
             [[4.0311456, 0.0, 0.0], [0.0, 4.0311456, 0.0], [0.0, 0.0, 4.0311456]]
-        )
+        ),
+        atol=1e-4,
     )
 
     # openmm box vectors end up as a list with contents; check to make sure we capture an error if we pass a bad list


### PR DESCRIPTION
## Description
This PR simplifies and removes much of the logic contained in the multistate sampler and adds support for offline free energy estimate based on MBAR.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] refactor multistate class
  - [x] store multistate energy matrix
  - [x] add MBAR analysis
  - [x] add free energy testcase (harmonic oscillator with different spring constant)

## Status
- [x] Ready to go