### PR TITLE
Using MCMCSampler instead of MCMCMove in multistate sampler

### DIFF
--- a/chiron/mcmc.py
+++ b/chiron/mcmc.py
@@ -272,18 +272,18 @@ class MCMCSampler:
     def __init__(
         self,
         move_set: MoveSchedule,
-        sampler_state: SamplerState,
-        thermodynamic_state: ThermodynamicState,
     ):
-        from copy import deepcopy
         from loguru import logger as log
 
-        log.info("Initializing Gibbs sampler")
+        log.info("Initializing MCMC sampler")
         self.move = move_set
-        self.sampler_state = deepcopy(sampler_state)
-        self.thermodynamic_state = deepcopy(thermodynamic_state)
 
-    def run(self, n_iterations: int = 1):
+    def run(
+        self,
+        sampler_state: SamplerState,
+        thermodynamic_state: ThermodynamicState,
+        n_iterations: int = 1,
+    ):
         """
         Run the sampler for a specified number of iterations.
 
@@ -293,6 +293,10 @@ class MCMCSampler:
             Number of iterations of the sampler to run.
         """
         from loguru import logger as log
+        from copy import deepcopy
+
+        sampler_state = deepcopy(sampler_state)
+        thermodynamic_state = deepcopy(thermodynamic_state)
 
         log.info("Running MCMC sampler")
         log.info(f"move_schedule = {self.move.move_schedule}")
@@ -300,14 +304,13 @@ class MCMCSampler:
             log.info(f"Iteration {iteration + 1}/{n_iterations}")
             for move_name, move in self.move.move_schedule:
                 log.debug(f"Performing: {move_name}")
-                move.run(self.sampler_state, self.thermodynamic_state)
+                move.run(sampler_state, thermodynamic_state)
 
         log.info("Finished running MCMC sampler")
         log.debug("Closing reporter")
         for _, move in self.move.move_schedule:
             if move.reporter is not None:
                 move.reporter.flush_buffer()
-                # TODO: flush reporter
                 log.debug(f"Closed reporter {move.reporter.log_file_path}")
 
 

--- a/chiron/mcmc.py
+++ b/chiron/mcmc.py
@@ -312,6 +312,7 @@ class MCMCSampler:
             if move.reporter is not None:
                 move.reporter.flush_buffer()
                 log.debug(f"Closed reporter {move.reporter.log_file_path}")
+        return sampler_state
 
 
 from .neighbors import PairsBase

--- a/chiron/multistate.py
+++ b/chiron/multistate.py
@@ -128,6 +128,7 @@ class MultiStateSampler:
 
         """
         import copy
+
         return copy.deepcopy(self._mcmc_sampler)
 
     @property
@@ -393,11 +394,11 @@ class MultiStateSampler:
         thermodynamic_state_id = self._replica_thermodynamic_states[replica_id]
         sampler_state = self._sampler_states[replica_id]
         thermodynamic_state = self._thermodynamic_states[thermodynamic_state_id]
-        mcmc_move = self._mcmc_sampler[thermodynamic_state_id]
-        # Apply the MCMC move to the replica.
-        mcmc_move.run(sampler_state, thermodynamic_state)
+        mcmc_sampler = self._mcmc_sampler[thermodynamic_state_id]
+        # Propagate using the mcmc sampler
+        self._sampler_states[replica_id] = mcmc_sampler.run(sampler_state, thermodynamic_state)
         # Append the new state to the trajectory for analysis.
-        self._traj[replica_id].append(sampler_state.x0)
+        self._traj[replica_id].append(self._sampler_states[replica_id].x0)
 
     def _perform_swap_proposals(self):
         """

--- a/chiron/tests/test_mcmc.py
+++ b/chiron/tests/test_mcmc.py
@@ -127,10 +127,12 @@ def test_sample_from_harmonic_osciallator_with_MCMC_classes_and_LangevinDynamics
     move_set = MoveSchedule([("LangevinMove", langevin_move)])
 
     # Initalize the sampler
-    sampler = MCMCSampler(move_set, sampler_state, thermodynamic_state)
+    sampler = MCMCSampler(move_set)
 
     # Run the sampler with the thermodynamic state and sampler state and return the sampler state
-    sampler.run(n_iterations=2)  # how many times to repeat
+    sampler.run(
+        sampler_state, thermodynamic_state, n_iterations=2
+    )  # how many times to repeat
 
 
 def test_sample_from_harmonic_osciallator_with_MCMC_classes_and_MetropolisDisplacementMove(
@@ -186,10 +188,12 @@ def test_sample_from_harmonic_osciallator_with_MCMC_classes_and_MetropolisDispla
     move_set = MoveSchedule([("MetropolisDisplacementMove", mc_displacement_move)])
 
     # Initalize the sampler
-    sampler = MCMCSampler(move_set, sampler_state, thermodynamic_state)
+    sampler = MCMCSampler(move_set)
 
     # Run the sampler with the thermodynamic state and sampler state and return the sampler state
-    sampler.run(n_iterations=2)  # how many times to repeat
+    sampler.run(
+        sampler_state, thermodynamic_state, n_iterations=2
+    )  # how many times to repeat
 
 
 def test_sample_from_harmonic_osciallator_array_with_MCMC_classes_and_MetropolisDisplacementMove(
@@ -246,10 +250,12 @@ def test_sample_from_harmonic_osciallator_array_with_MCMC_classes_and_Metropolis
     move_set = MoveSchedule([("MetropolisDisplacementMove", mc_displacement_move)])
 
     # Initalize the sampler
-    sampler = MCMCSampler(move_set, sampler_state, thermodynamic_state)
+    sampler = MCMCSampler(move_set)
 
     # Run the sampler with the thermodynamic state and sampler state and return the sampler state
-    sampler.run(n_iterations=2)  # how many times to repeat
+    sampler.run(
+        sampler_state, thermodynamic_state, n_iterations=2
+    )  # how many times to repeat
 
 
 def test_thermodynamic_state_inputs():

--- a/chiron/tests/test_multistate.py
+++ b/chiron/tests/test_multistate.py
@@ -217,7 +217,7 @@ def test_multistate_run(ho_multistate_sampler_multiple_ks: MultiStateSampler):
 
     print(f"Analytical free energy difference: {ho_sampler.delta_f_ij_analytical[0]}")
 
-    n_iteratinos = 250
+    n_iteratinos = 25
     ho_sampler.run(n_iteratinos)
 
     # check that we have the correct number of iterations, replicas and states


### PR DESCRIPTION
## Description
As the title says, using the MCMCSampler, which is a sequence of composed MCMCMoves that transformed sampler states using a specific thermodynamic state, for the MultistateSampler.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Adding MCMCSampler to MultisateSampler
  - [x] cleaning up tests

## Status
- [x] Ready to go